### PR TITLE
Remove funky colors from home screen

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -89,20 +89,5 @@ div.gm-style-iw{
 //	color: white;
 }
 
-// RANDOM COLORS ON THE HOME PAGE
-#ext-element-49{
-	background-color: #00FF00;
-}
-#ext-element-40{
-	background-color: red;
-}
-#ext-input-4{
-	background-color: #990099;
-}
-#ext-input-5{
-	background-color: #33CC00;
-}
-
-
 // Examples of using the icon mixin:
 // @include icon('user');


### PR DESCRIPTION
This commit removes the neon purple and neon green colors from the
Home screen. Yes, we had grown to love them. But it's time to let go.

This commit re-implements pull request #2 because it was easier/faster to make this 14-line pull request than to break out the #2 feature commit from behind the redundant commit and rebase to dev branch.
