### PR TITLE
Fix back button problems and map loading - rebased

### DIFF
--- a/app/controller/List.js
+++ b/app/controller/List.js
@@ -780,6 +780,11 @@ Ext.define('WhatsFresh.controller.List', {
 			}
 			// Sets the title of the header on detail page
 			Ext.ComponentQuery.query('toolbar[itemId=detailPageToolbar]')[0].setTitle(index.data.name);
+			console.log('Checking index for location data');
+			console.log(detailView);
+			var dest = 'http://maps.googleapis.com/maps/api/staticmap?center='+ detailView.items.items[1]._data.lat +','+ detailView.items.items[1]._data.lng +'&zoom=14&size=200x200&maptype=roadmap&markers=color:blue%7Clabel:%7C'+ detailView.items.items[1]._data.lat +','+ detailView.items.items[1]._data.lng;
+			console.log(dest);
+			WhatsFresh.statmap.setSrc(dest);
 			if(WhatsFresh.backFlag === 0){
 				// adding a log item to the "stack"
 				WhatsFresh.path[WhatsFresh.pcount] = 'detail';
@@ -796,7 +801,8 @@ Ext.define('WhatsFresh.controller.List', {
 	        			num2 = w;
 	        		}
 	        	}
-	       		detailView.items.items[2].select(storeInventory.data.all[num2]);
+	        	console.log(detailView.items);
+	       		detailView.items.items[3].select(storeInventory.data.all[num2]);
 	        	Ext.Viewport.animateActiveItem(detailView, this.slideRightTransition);
 	        }
 		}		


### PR DESCRIPTION
I was able to fix the back button problems, by refering to the correct
screen element in the on back cmd. I was also able to solve the map
loading problem, because it seems that I only loaded the map when a user
navigated from the list page to the detail page, and forgot to reset the
map when the detail page was navigated to by the productsdetail page.

---

This branch was rebased from #3 pull request branch such that it only includes feature code under the new "WhatsFresh" name.
