### PR TITLE
Change '{' to '[' in distanceSpec.js jasmine test

### DIFF
--- a/tests/jasmine-standalone/spec/javascripts/store/distanceSpec.js
+++ b/tests/jasmine-standalone/spec/javascripts/store/distanceSpec.js
@@ -52,7 +52,7 @@ describe('WhatsFresh.store.Distance',function() {
         expect(store.data.items[10].data.val).toEqual(10);
     });
     it('Is populated with distance data', function(){
-        expect(store.data.items{11].data.val).toEqual(5);
+        expect(store.data.items[11].data.val).toEqual(5);
     });
 
 });


### PR DESCRIPTION
Prior to this commit, the distanceSpec test had a syntax error
preventing successful testing. This commit fixes a curly brace and
resolves the test.