### PR TITLE
Add .editorconfig file to root of project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
This commit introduces a .editorconfig file to the root of the project
to alleviate some of the whitespace commits that get introduced as we
work in different editors. See editorconfig.org for more information.