### PR TITLE
Fix infowindow navigation issues

### DIFF
--- a/app/controller/List.js
+++ b/app/controller/List.js
@@ -398,16 +398,22 @@ Ext.define('WhatsFresh.controller.List', {
 				icon: WhatsFresh.iconImage,
 				position: WhatsFresh.cent[k],
 				clickable: true
-			});			
+			});	
+			console.log("Map marker is created");		
 			// THIS FUNCTION ADDS A CLICKABLE MARKER INFO WINDOW FOR EACH SPECIFIC MARKER
         	WhatsFresh.marker[k].info = new google.maps.InfoWindow({
         		content: '<button onclick=\"javascript:WhatsFresh.infoClickSelf.onInfoWindowClick();\">'+ vendorStore.data.items[k].data.name + '</button>',
         		data: vendorStore.data.items[k].data,
         		Lpos: k // used to index and highlight the correct list item
         	});
+        	// console.log(this);
+        	console.log(WhatsFresh.marker[k]);
+        	WhatsFresh.storeItem = WhatsFresh.marker[k];
         	// NOW WE ADD AN ON CLICK EVENT LISTENER TO EACH MARKER
         	// WE WILL USE THIS LISTENER TO OPEN THE SPECIFIC MARKER INFO THAT WAS CLICKED
         	google.maps.event.addListener(WhatsFresh.marker[k], 'click', function(){
+        		// turns out that this is equal to WhatsFresh.marker[k], so we set WhatsFresh.storeItem 
+        		// to WhatsFresh.marker[k] above so that the storeItem is set when a list item is selected
         		WhatsFresh.storeItem = this;
         		// console.log('THIS IN THE EVENT LISTENER');
         		// console.log(this);
@@ -677,7 +683,7 @@ Ext.define('WhatsFresh.controller.List', {
 	onViewBackListCommand: function(record, index){
 		console.log('In controller(detail): Back to List Page Button');
 		var a, b;
-		
+		WhatsFresh.previousListItem = null;
 		// console.log("this is our path item **************************");
 
 		// console.log('WhatsFresh.pcount - 2');


### PR DESCRIPTION
I realized that the infowindow button was not being populated with the
data it needed to navigate to the detail page, so we made that possible by
setting WhatsFresh.storeItem outside of the added listener for the map
markers. This way the list would be able to set the data the infowindow
button needed, when it opened the infowindow corresponding to the list
item. Also had to fix an issue where the previously highlighted list item
was not being changed, so we set it to null when the user navigates back
from the detail page.