### PR TITLE
Implement search util

### DIFF
--- a/app/controller/List.js
+++ b/app/controller/List.js
@@ -4,7 +4,7 @@ isPresent = true;
 
 Ext.define('WhatsFresh.controller.List', {
 	extend: 'Ext.app.Controller',
-	requires: ['Ext.MessageBox', 'Ext.device.Geolocation', 'WhatsFresh.util.Link'],
+	requires: ['Ext.MessageBox', 'Ext.device.Geolocation', 'WhatsFresh.util.Geography', 'WhatsFresh.util.Search'],
 	alias: 'cont',
 	config: {
 		refs: {
@@ -110,7 +110,10 @@ Ext.define('WhatsFresh.controller.List', {
 		var vendorStore = Ext.data.StoreManager.lookup('Vendor');
 		var productStore = Ext.data.StoreManager.lookup('ProductList');
 
-            this.filterVendorStore(WhatsFresh.location, WhatsFresh.product);
+			WhatsFresh.util.Search.options.location = record._value.data;
+            // WhatsFresh.VendorStore.filter();
+            WhatsFresh.util.Search.applyFilterToStore(WhatsFresh.VendorStore);
+
 
 	    var homeView = this.getHomeView();
             homeView.getComponent('vendnum').setData(this.buildInventorySummary(WhatsFresh.location, WhatsFresh.product));
@@ -124,9 +127,10 @@ Ext.define('WhatsFresh.controller.List', {
 		WhatsFresh.product = record._value.data.name;
 		var vendorStore = Ext.data.StoreManager.lookup('Vendor');
 		var productStore = Ext.data.StoreManager.lookup('ProductList');
-		// console.log(store.data.all);
-		// console.log(store);
-            this.filterVendorStore(WhatsFresh.location, WhatsFresh.product);
+
+			WhatsFresh.util.Search.options.product = record._value.data;
+            // this.filterVendorStore(WhatsFresh.location, WhatsFresh.product);
+            WhatsFresh.util.Search.applyFilterToStore(WhatsFresh.VendorStore);
 
 	    var homeView = this.getHomeView();
             homeView.getComponent('vendnum').setData(this.buildInventorySummary(WhatsFresh.location, WhatsFresh.product));       
@@ -1062,6 +1066,9 @@ Ext.define('WhatsFresh.controller.List', {
 		WhatsFresh.StoryStore = Ext.getStore('Story');
 		WhatsFresh.VendorStore = Ext.getStore('Vendor');
 		WhatsFresh.VendorInventoryStore = Ext.getStore('VendorInventory');
+
+		// Applying filters to stores
+		WhatsFresh.util.Search.applyFilterToStore(WhatsFresh.VendorStore);
 
 		// Components
 			// ON: List page

--- a/app/model/Locations.js
+++ b/app/model/Locations.js
@@ -11,7 +11,8 @@ Ext.define('WhatsFresh.model.Locations', {
             'id',
             'address',
             'desc',
-            'name'
+            'name',
+            'is_not_filterable'
         ]
     }
 });

--- a/app/model/Products.js
+++ b/app/model/Products.js
@@ -15,7 +15,8 @@ Ext.define('WhatsFresh.model.Products', {
             'alt_name',
             'story',
             'name',
-            'id'
+            'id',
+            'is_not_filterable'
         ]
     }
 });

--- a/app/store/Location.js
+++ b/app/store/Location.js
@@ -9,7 +9,8 @@ Ext.define('WhatsFresh.store.Location', {
                 locationStore.insert( 0, 
                     {
                         name: "Please choose a location",
-                        location: locationIndex
+                        location: locationIndex,
+                        is_not_filterable: true
                     }
                 );
                 //console.log("Location Store: autoload result records:");

--- a/app/store/Product.js
+++ b/app/store/Product.js
@@ -8,6 +8,7 @@ Ext.define('WhatsFresh.store.Product', {
                 productStore.insert( 0, [
                     {
                         name: "Please choose a product",
+                        is_not_filterable: true
                     }
                 ]);
                 console.log("Product Store: autoload result records:");

--- a/app/util/Geography.js
+++ b/app/util/Geography.js
@@ -1,0 +1,71 @@
+Ext.define('WhatsFresh.util.Geography', {
+
+	// Class should be used statically.
+	singleton: true,
+
+	// WolframAlpha
+	Reference: {
+		Earth: {
+			'average radius'	: 6367444.7,	// meters
+			'oblateness'		: 0.0033528197	// unitless
+		},
+		Units: {
+			'miles': {
+				meters			: 1609.344
+			},
+			'meters': {
+				meters			: 1.0
+			}
+		}
+	},
+
+	/**
+	 * Calculates distance between two Earth surface coordinates.
+	 * Uses haversine formula for great-circle minumum distance.
+	 * DOES NOT use oblateness.
+	 * DOES NOT use significant figures.
+	 * From: http://www.movable-type.co.uk/scripts/latlong.html
+	 * @param  {number} lat1	First point's latitude.
+	 * @param  {number} lng1	First point's longitude.
+	 * @param  {number} lat2	Second point's latitude.
+	 * @param  {number} lng2	Second point's longitude.
+	 * @return {number}			Sphere arc length in meters.
+	 */
+	getDistance: function (lat1, lng1, lat2, lng2) {
+		var geo	= WhatsFresh.util.Geography;
+		var R	= geo.Reference.Earth['average radius'];
+		var φ1	= geo.degreesToRadians(lat1);
+		var φ2	= geo.degreesToRadians(lat2);
+		var Δφ	= geo.degreesToRadians(lat2-lat1); // φ is latitude
+		var Δλ	= geo.degreesToRadians(lng2-lng1); // λ is longitude
+		var a	= Math.sin(Δφ/2) * Math.sin(Δφ/2) +
+					Math.cos(φ1) * Math.cos(φ2) *
+					Math.sin(Δλ/2) * Math.sin(Δλ/2);
+		var c	= 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+		var d	= R * c;
+		return d;
+	},
+
+	/**
+	 * Only accepts what units are defined in Reference above.
+	 */
+	standardizeDistance: function (distanceRecord) {
+		var Units = WhatsFresh.util.Geography.Reference.Units;
+		return Units[distanceRecord.unit].meters * distanceRecord.value;
+	},
+
+	/* ------------------------------------------------------------------------
+		Utility and Helper Functions
+	------------------------------------------------------------------------ */
+
+	// Converts Euclidean degrees into radians.
+	degreesToRadians: function (degrees) {
+		return degrees * Math.PI / 180;
+	},
+
+	// Converts Euclidean radians into degress.
+	radiansToDegrees: function (radians) {
+		return radians * 180 / Math.PI;
+	}
+
+});

--- a/app/util/Search.js
+++ b/app/util/Search.js
@@ -1,0 +1,118 @@
+Ext.define('WhatsFresh.util.Search', {
+
+    singleton: true,
+
+    requires: ['WhatsFresh.util.Geography'],
+    // Each of these options are of type record,
+    // Thus we must send in a record from the controller
+    options: {
+        position: null,
+        distance: null,
+        location: null,
+        product: null
+    },
+
+    constructor: function() {},
+
+    /* ------------------------------------------------------------------------
+       Filter Definition
+       ------------------------------------------------------------------------
+    */
+
+    buildFilterFunction: function () {
+        var singleton = WhatsFresh.util.Search;
+        var Geo = WhatsFresh.util.Geography;
+        var filter = function (vendorStoreRecord) {
+            var pos= singleton.options.position;
+            var dist= singleton.options.distance;
+            var loc= singleton.options.location;
+            var prod= singleton.options.product;
+           
+            // Composable filters
+            var hasProduct, isNear, isInCity;
+
+            // Discard placeholders
+            if (vendorStoreRecord.is_not_filterable) return false;
+
+            // If position and distance are set, filter on those. If
+            // not, include everything.
+            if (singleton.canFilterByDistance()) {
+                var φ1= pos.coords.latitude;
+                var λ1= pos.coords.longitude;
+                var φ2= vendorStoreRecord.get('lat');
+                var λ2= vendorStoreRecord.get('lng');
+                var dMax= Geo.standardizeDistance(dist);
+                var dCurr= Geo.getDistance(φ1,λ1,φ2,λ2);
+                isNear= dMax - dCurr >= 0;
+            } else {
+                isNear= true;
+            }
+
+            // If location is set, filter on that. If not, include everything.
+            if (singleton.canFilterByLocation()) {
+                isInCity= loc.name === vendorStoreRecord.get('city');
+            } else {
+                isInCity= true;
+            }
+
+            // If the product is set, filter. If not, include everything.
+            if (singleton.canFilterByProduct()) {
+                var vendorProducts= vendorStoreRecord.get('products');
+                hasProduct= false;
+                for (var i = 0; i < vendorProducts.length; i++){
+                    if (prod.name === vendorProducts[i].name){
+                        hasProduct = true;
+                        break;
+                    }
+                }
+            } else {
+                hasProduct= true;
+            }
+            // Return all filters
+            return isNear && isInCity && hasProduct;
+        };
+        return filter;
+    },
+
+    /*
+     * This function assembles and applies the Search util's filter
+     * to a store. 
+     *
+     * Because Sencha stores persist applied filters, we only need to
+     * call this function once on startup. Once the filter is applied,
+     * we can call the store's filter function to update the filtered set.
+     */
+    applyFilterToStore: function (store) {
+        var singleton= WhatsFresh.util.Search;
+        var filterFunction = singleton.buildFilterFunction();
+        var criteria = new Ext.util.Filter({
+            filterFn : filterFunction,
+            root     : 'data'
+        });
+        store.clearFilter();
+        store.filter(criteria);
+    },
+
+    /* ------------------------------------------------------------------------
+       Utility and Helper Functions
+       ------------------------------------------------------------------------
+    */
+
+    canFilterByDistance: function () {
+        var opt = this.options;
+        var hasPosition = !!opt.position && !!opt.position.coords;
+        var hasDistance = !!opt.distance && !!opt.distance.value;
+        return hasPosition && hasDistance;
+    },
+
+    canFilterByLocation: function () {
+        var opt = this.options;
+        var isValidLocation = !!opt.location && !opt.location.is_not_filterable;
+        return !this.canFilterByDistance() && isValidLocation;
+    },
+    
+    canFilterByProduct: function () {
+        var opt = this.options;
+        return !!opt.product && !opt.product.is_not_filterable;
+    }
+});

--- a/tests/jasmine-standalone/SpecRunner.html
+++ b/tests/jasmine-standalone/SpecRunner.html
@@ -31,6 +31,10 @@
   <script type="text/javascript" src="../../app/store/Vendor.js"></script>
   <script type="text/javascript" src="../../app/store/VendorInventory.js"></script>
 
+  <!-- Utils -->
+  <script type="text/javascript" src="../../app/util/Geography.js"></script>
+  <script type="text/javascript" src="../../app/util/Search.js"></script>
+
   <!-- Views -->
 
   <!-- Controller -->
@@ -62,7 +66,11 @@
   <script type="text/javascript" src="spec/javascripts/store/productSpec.js"></script>
   <script type="text/javascript" src="spec/javascripts/store/vendorSpec.js"></script>
   <script type="text/javascript" src="spec/javascripts/store/vendorInventorySpec.js"></script>
- 
+  <!-- Util Testing Spec files -->
+  <script type="text/javascript" src="spec/javascripts/util/geographySpec.js"></script>
+  <script type="text/javascript" src="spec/javascripts/util/searchSpec.js"></script>
+  <!-- Helper Testing Spec files -->
+  <script type="text/javascript" src="spec/javascripts/helpers/test-data.js"></script>
 
 
 </head>

--- a/tests/jasmine-standalone/spec/javascripts/helpers/test-data.js
+++ b/tests/jasmine-standalone/spec/javascripts/helpers/test-data.js
@@ -1,0 +1,176 @@
+// Creates global objects that contain test data.
+// This is to be kept up-to-date with the API
+
+// Assign the Global Variable
+window.TestData = {};
+
+// Please don't judge me.
+// This function adds a get() method to the object to
+// make it look like a store model/record.
+TestData.modelify = function (obj) {
+    obj = JSON.parse(JSON.stringify(obj));
+    obj.get = function (key) { return this[key]; };
+    return obj;
+};
+
+TestData.VendorArray = [
+    {
+        city: 'Newport',
+        updated: true,
+        description: 'a place with stuff',
+        zip: '97523',
+        created: true,
+        ext: false,
+        location_description: 'its a place with a thing',
+        lat: '44.0',
+        lng: '120.0',
+        email: 'user@email.com',
+        website: 'site.com',
+        phone: '555-555-5555',
+        state: 'OR',
+        street: 'corner street',
+        products: [
+            {
+                name : 'One Fish',
+                preparation : 'Live',
+            },
+            {
+                name : 'Two Fish',
+                preparation : 'Filet'
+            }            
+        ],
+        contact_name: 'John Doe',
+        story: 'see other side',
+        name: 'fish place',
+        is_not_filterable: false
+        },
+    {
+        city: 'Coos Bay',
+        updated: false,
+        description: 'stuff',
+        zip: '97420',
+        created: true,
+        ext: false,
+        location_description: 'its a place with a thing2',
+        lat: '44.0',
+        lng: '121.0',
+        email: 'user@email.com2',
+        website: 'site.com2',
+        phone: '555-555-2222',
+        state: 'OR',
+        street: 'corner street2',
+        products: [
+            {
+                name : 'Red Fish',
+                preparation : 'Dried'        
+            },
+            {
+                name : 'Blue Fish',
+                preparation : 'Frozen'        
+            }
+        ],
+        contact_name: 'J.D. Smith',
+        story: 'none',
+        name: 'fishy',
+        is_not_filterable: false
+        },
+    {
+        city: 'Coos Bay',
+        updated: false,
+        description: 'stuff',
+        zip: '97420',
+        created: true,
+        ext: false,
+        location_description: 'its a place with a thing2',
+        lat: '45.0',
+        lng: '121.0',
+        email: 'user@email.com2',
+        website: 'site.com2',
+        phone: '555-555-2222',
+        state: 'OR',
+        street: 'corner street2',
+        products: [
+            {
+                name : 'One Fish',
+                preparation : 'Live',
+            },
+            {
+                name : 'Two Fish',
+                preparation : 'Filet'
+            },
+            {
+                name : 'Red Fish',
+                preparation : 'Dried'        
+            },
+            {
+                name : 'Blue Fish',
+                preparation : 'Frozen'        
+            }
+        ],
+        contact_name: 'J.D. Smith',
+        story: 'none',
+        name: 'Test Store',
+        is_not_filterable: false
+        },
+    {
+        city: 'Newport',
+        updated: false,
+        description: 'stuff',
+        zip: '97420',
+        created: true,
+        ext: false,
+        location_description: 'A test store with no inventory with the name: Newport',
+        lat: '45.0',
+        lng: '121.0',
+        email: 'user@email.com2',
+        website: 'site.com2',
+        phone: '555-555-2222',
+        state: 'OR',
+        street: 'corner street2',
+        products: [
+            {
+                name : 'Blue Fish',
+                preparation : 'Frozen'        
+            }
+        ],
+        contact_name: 'J.D. Smith',
+        story: 'none',
+        name: 'Not Actually In Newport',
+        is_not_filterable: false
+        },
+    {
+        name: '--Not Filterable--',
+        description: 'A test datum simulating a label/placeholder',
+        is_not_filterable: true
+    }
+];
+
+TestData.LocationArray = [
+    {
+        location: 1,
+        name: 'Newport'
+        },
+    {
+        location: 2,
+        name: 'Coos Bay'
+        }
+];
+
+TestData.ProductArray = [
+    {
+        name : 'One Fish',
+        preparation : 'Live',
+    },
+    {
+        name : 'Two Fish',
+        preparation : 'Filet'
+    },
+    {
+        name : 'Red Fish',
+        preparation : 'Dried'        
+    },
+    {
+        name : 'Blue Fish',
+        preparation : 'Frozen'        
+    }
+];

--- a/tests/jasmine-standalone/spec/javascripts/model/productsSpec.js
+++ b/tests/jasmine-standalone/spec/javascripts/model/productsSpec.js
@@ -31,14 +31,14 @@ describe('WhatsFresh.model.Products', function() {
             market_price: 0,
             link: null,
             alt_name: 'Pretend Product, Elaborate Ruse',
-            story_id: null,
+            story: null,
             name: 'Test Product Instance'
         });
         
         //Justin will expect these to be moved into a helper function.
         //Please see Justin if you have questions.
         expect(model.get('name')).toEqual('Test Product Instance');
-        expect(model.get('story_id')).toBeNull();
+        expect(model.get('story')).toBeNull();
         expect(model.get('alt_name')).toEqual('Pretend Product, Elaborate Ruse');
         expect(model.get('link')).toBeNull();
         expect(model.get('market_price')).toEqual(0);

--- a/tests/jasmine-standalone/spec/javascripts/store/productSpec.js
+++ b/tests/jasmine-standalone/spec/javascripts/store/productSpec.js
@@ -41,7 +41,7 @@ describe('WhatsFresh.store.Product',function() {
                     market_price: 0,
                     link: null,
                     alt_name: 'Pretend Product, Elaborate Ruse',
-                    story_id: null,
+                    story: null,
                     name: 'Test Product Instance'
 		}
 	    ]
@@ -58,7 +58,7 @@ describe('WhatsFresh.store.Product',function() {
 	expect(store.getAt(0).get('market_price')).toEqual(0);
 	expect(store.getAt(0).get('link')).toEqual(null);
 	expect(store.getAt(0).get('alt_name')).toEqual('Pretend Product, Elaborate Ruse');
-        expect(store.getAt(0).get('story_id')).toEqual(null);
+        expect(store.getAt(0).get('story')).toEqual(null);
 	expect(store.getAt(0).get('name')).toEqual('Test Product Instance');
     });
 
@@ -80,7 +80,7 @@ describe('WhatsFresh.store.Product',function() {
                     market_price: 0,
                     link: null,
                     alt_name: 'Pretend Product, Elaborate Ruse',
-                    story_id: null,
+                    story: null,
                     name: 'Test Product Instance'
 		},
 		{
@@ -95,7 +95,7 @@ describe('WhatsFresh.store.Product',function() {
                     market_price: 10.55,
                     link: null,
                     alt_name: 'Pretend Product, Elaborate Ruse2',
-                    story_id: null,
+                    story: null,
                     name: 'Test Product Instance2'
 		}
 	    ]
@@ -112,7 +112,7 @@ describe('WhatsFresh.store.Product',function() {
 	expect(store.getAt(0).get('market_price')).toEqual(0);
 	expect(store.getAt(0).get('link')).toEqual(null);
         expect(store.getAt(0).get('alt_name')).toEqual('Pretend Product, Elaborate Ruse');
-        expect(store.getAt(0).get('story_id')).toEqual(null);
+        expect(store.getAt(0).get('story')).toEqual(null);
         expect(store.getAt(0).get('name')).toEqual('Test Product Instance');
 
 	//data store 2
@@ -127,7 +127,7 @@ describe('WhatsFresh.store.Product',function() {
         expect(store.getAt(1).get('market_price')).toEqual(10.55);
         expect(store.getAt(1).get('link')).toEqual(null);
         expect(store.getAt(1).get('alt_name')).toEqual('Pretend Product, Elaborate Ruse2');
-        expect(store.getAt(1).get('story_id')).toEqual(null);
+        expect(store.getAt(1).get('story')).toEqual(null);
         expect(store.getAt(1).get('name')).toEqual('Test Product Instance2');
     });
 

--- a/tests/jasmine-standalone/spec/javascripts/util/geographySpec.js
+++ b/tests/jasmine-standalone/spec/javascripts/util/geographySpec.js
@@ -1,0 +1,23 @@
+describe('WhatsFresh.util.Geography', function () {
+
+    Ext.require('WhatsFresh.util.Geography');
+    /* global WhatsFresh */
+
+    it('exists as a global singleton', function() {
+        expect(WhatsFresh.util.Geography).toBeDefined();
+        });
+
+    describe('getDistance()', function () {
+
+        it('calculates distance between points accurate to 100m', function () {
+            var φ1= 44.0;
+            var λ1= 120.0;
+            var φ2= 44.0;
+            var λ2= 121.0;
+            var d = WhatsFresh.util.Geography.getDistance(φ1,λ1,φ2,λ2);
+            expect(Math.abs(79990 - d)).toBeLessThan(100);
+            });
+
+        });
+
+});

--- a/tests/jasmine-standalone/spec/javascripts/util/searchSpec.js
+++ b/tests/jasmine-standalone/spec/javascripts/util/searchSpec.js
@@ -1,0 +1,389 @@
+describe('WhatsFresh.util.Search', function () {
+
+    Ext.require('WhatsFresh.util.Search');
+    /* global WhatsFresh */
+
+    it('exists as a global singleton', function() {
+        expect(WhatsFresh.util.Search).toBeDefined();
+    });
+
+    it('has options that are null by default', function() {
+        expect(WhatsFresh.util.Search.options).toBeDefined();
+        expect(WhatsFresh.util.Search.options.position).toBeNull();
+        expect(WhatsFresh.util.Search.options.distance).toBeNull();
+        expect(WhatsFresh.util.Search.options.location).toBeNull();
+        expect(WhatsFresh.util.Search.options.product).toBeNull();
+    });
+
+    it('has filter-by logic functions', function() {
+        var Search = WhatsFresh.util.Search;
+        expect(Search.canFilterByDistance).toBeDefined();
+        expect(Search.canFilterByLocation).toBeDefined();
+        expect(Search.canFilterByProduct).toBeDefined();
+    });
+
+    it('can create a store-filtering function', function() {
+        var Search = WhatsFresh.util.Search;
+        expect(Search.buildFilterFunction).toBeDefined();
+        var filter = Search.buildFilterFunction();
+        expect(filter).toBeDefined();
+    });
+
+    describe('buildFilterFunction()', function () {
+
+        var Search = WhatsFresh.util.Search;
+
+        beforeEach(function () {
+            // Reset the properties on the singleton.
+            // Prevents cross-test pollution.
+            Search.options.position = null;
+            Search.options.distance = null;
+            Search.options.location = null;
+            Search.options.product  = null;
+            // These may be overridden by testcase beforeEach
+        });
+
+        describe('where all options are null', function () {
+
+            it('cannot filter-by distance', function() {
+                expect(Search.canFilterByDistance()).toBe(false);
+            });
+
+            it('cannot filter-by location', function() {
+                expect(Search.canFilterByLocation()).toBe(false);
+            });
+
+            it('cannot filter-by product', function() {
+                expect(Search.canFilterByProduct()).toBe(false);
+            });
+
+            it('includes any vendor', function() {
+                var filter = Search.buildFilterFunction();
+                var anyVendor = TestData.VendorArray[0];
+                expect(filter(anyVendor)).toBe(true);
+            });
+
+        });
+
+        describe('where position and distance are set and product is not set', function () {
+
+            var filter;
+
+            beforeEach(function () {
+                Search.options.position = {
+                    coords: {
+                        latitude: 44.0,
+                        longitude: 120.0
+                    }
+                };
+                Search.options.distance = {
+                    value: 50,
+                    unit: 'miles'
+                };
+                filter = Search.buildFilterFunction();
+            });
+
+            afterEach(function () {
+                filter = null;
+            });
+
+            it('can filter-by distance', function () {
+                expect(Search.canFilterByDistance()).toBe(true);
+            });
+
+            it('cannot filter-by location', function () {
+                expect(Search.canFilterByLocation()).toBe(false);
+            });
+
+            it('cannot filter-by product', function() {
+                expect(Search.canFilterByProduct()).toBe(false);
+            });
+
+            it('includes a point within 50 miles', function () {
+                var model = TestData.modelify(TestData.VendorArray[0]);
+                expect(filter(model)).toBe(true);
+            });
+
+            it('includes a point still within 50 miles', function () {
+                var model = TestData.modelify(TestData.VendorArray[1]);
+                expect(filter(model)).toBe(true);
+            });
+
+            it('excludes a point beyond 50 miles', function () {
+                var model = TestData.modelify(TestData.VendorArray[2]);
+                expect(filter(model)).toBe(false);
+            });
+
+        });
+
+        describe('where location is set and product is not set', function () {
+
+            var filter;
+
+            beforeEach(function () {
+                Search.options.location = TestData.LocationArray[0];
+                filter = Search.buildFilterFunction();
+            });
+
+            afterEach(function () {
+                filter = null;
+            });
+
+            it('cannot filter-by distance', function () {
+                expect(Search.canFilterByDistance()).toBe(false);
+            });
+
+            it('can filter-by location', function () {
+                expect(Search.canFilterByLocation()).toBe(true);
+            });
+
+            it('cannot filter-by product', function() {
+                expect(Search.canFilterByProduct()).toBe(false);
+            });
+
+            it('includes a point with same city name', function () {
+                var model = TestData.modelify(TestData.VendorArray[0]);
+                expect(filter(model)).toBe(true);
+            });
+
+            it('excludes a point with different city name', function () {
+                var model = TestData.modelify(TestData.VendorArray[1]);
+                expect(filter(model)).toBe(false);
+            });
+
+            it('excludes a point with no city name', function () {
+                var model = TestData.modelify(TestData.VendorArray[2]);
+                expect(filter(model)).toBe(false);
+            });
+
+        });
+
+        describe('where position and location are set, but product is not', function () {
+
+            var filter;
+
+            beforeEach(function () {
+                Search.options.position = {
+                    coords: {
+                        latitude: 44.0,
+                        longitude: 120.0
+                    }
+                };
+                Search.options.distance = {
+                    value: 50,
+                    unit: 'miles'
+                };
+                Search.options.location = TestData.LocationArray[0];
+                filter = Search.buildFilterFunction();
+            });
+
+            afterEach(function () {
+                filter = null;
+            });
+
+            it('can filter-by distance', function () {
+                expect(Search.canFilterByDistance()).toBe(true);
+            });
+
+            it('cannot filter-by location', function () {
+                expect(Search.canFilterByLocation()).toBe(false);
+            });
+
+            it('cannot filter-by product', function() {
+                expect(Search.canFilterByProduct()).toBe(false);
+            });
+
+            it('includes a point within 50 miles with no city', function () {
+                var model = TestData.modelify(TestData.VendorArray[0]);
+                expect(filter(model)).toBe(true);
+            });
+
+            it('excludes a point beyond 50 miles with same city', function () {
+                var model = TestData.modelify(TestData.VendorArray[2]);
+                expect(filter(model)).toBe(false);
+            });
+
+        });
+
+        describe('when only product is set', function () {
+            
+            var filter;
+
+            beforeEach( function (){
+                Search.options.product= TestData.ProductArray[0];
+                filter= Search.buildFilterFunction();
+            });
+
+            afterEach( function (){
+                filter= null;
+            });
+
+            it('cannot filter-by distance', function () {
+                expect(Search.canFilterByDistance()).toBe(false);
+            });
+
+            it('cannot filter-by location', function () {
+                expect(Search.canFilterByLocation()).toBe(false);
+            });
+
+            it('can filter-by product', function() {
+                expect(Search.canFilterByProduct()).toBe(true);
+            });
+
+            it('includes a vendor with the given product', function () {
+                var model= TestData.modelify(TestData.VendorArray[0]);
+                expect(filter(model)).toBe(true);
+            });
+
+            it('excludes a vendor not carrying the given product', function () {
+                var model= TestData.modelify(TestData.VendorArray[1]);
+                expect(filter(model)).toBe(false);
+            });
+
+        });
+
+        describe('when position and distance are set and product is set.', function () {
+
+            var filter;
+
+            beforeEach( function (){
+                Search.options.position = {
+                    coords: {
+                        latitude: 44.0,
+                        longitude: 120.0
+                    }
+                };
+                Search.options.distance = {
+                    value: 50,
+                    unit: 'miles'
+                };
+                Search.options.product= TestData.ProductArray[0];
+                filter= Search.buildFilterFunction();
+            });
+
+            afterEach( function (){
+                filter= null;
+            });
+
+            it('can filter-by distance', function () {
+                expect(Search.canFilterByDistance()).toBe(true);
+            });
+
+            it('cannot filter-by location', function () {
+                expect(Search.canFilterByLocation()).toBe(false);
+            });
+
+            it('can filter-by product', function() {
+                expect(Search.canFilterByProduct()).toBe(true);
+            });
+
+            it('includes a point within 50 miles with selected product', function () {
+                var model = TestData.modelify(TestData.VendorArray[0]);
+                expect(filter(model)).toBe(true);
+            });
+
+            it('excludes a point beyond 50 miles with selected product', function () {
+                var model = TestData.modelify(TestData.VendorArray[2]);
+                expect(filter(model)).toBe(false);
+            });
+
+            it('excludes a point within 50 miles and different products', function () {
+                var model = TestData.modelify(TestData.VendorArray[3]);
+                expect(filter(model)).toBe(false);
+            });
+            
+        });
+
+        describe('When location is set and product is set', function () {
+
+            var filter;
+
+            beforeEach( function (){
+                Search.options.location = TestData.LocationArray[0];
+                Search.options.product= TestData.ProductArray[0];
+                filter= Search.buildFilterFunction();
+            });
+
+            afterEach( function (){
+                filter= null;
+            });
+
+            it('cannot filter-by distance', function () {
+                expect(Search.canFilterByDistance()).toBe(false);
+            });
+
+            it('can filter-by location', function () {
+                expect(Search.canFilterByLocation()).toBe(true);
+            });
+
+            it('can filter-by product', function() {
+                expect(Search.canFilterByProduct()).toBe(true);
+            });
+
+            it('includes a point with same city name and selected product', function () {
+                var model = TestData.modelify(TestData.VendorArray[0]);
+                expect(filter(model)).toBe(true);
+            });
+
+            it('excludes a point with different city name and selected product', function () {
+                var model = TestData.modelify(TestData.VendorArray[2]);
+                expect(filter(model)).toBe(false);
+            });
+
+            it('excludes a point with same city name and different products', function () {
+                var model = TestData.modelify(TestData.VendorArray[3]);
+                expect(filter(model)).toBe(false);
+            });
+
+        });
+
+        describe('When all options are set', function () {
+
+            var filter;
+
+            beforeEach( function (){
+                Search.options.position = {
+                    coords: {
+                        latitude: 44.0,
+                        longitude: 120.0
+                    }
+                };
+                Search.options.distance = {
+                    value: 50,
+                    unit: 'miles'
+                };
+                Search.options.location = TestData.LocationArray[0];
+                Search.options.product= TestData.ProductArray[0];
+                filter= Search.buildFilterFunction();
+            });
+
+            afterEach( function (){
+                filter= null;
+            });
+
+            it('filter behaves as though distance and product are set', function() {
+                expect(Search.canFilterByDistance()).toBe(true);
+                expect(Search.canFilterByLocation()).toBe(false);
+                expect(Search.canFilterByProduct()).toBe(true);
+            });
+
+            it('includes a point within 50 miles with selected product', function () {
+                var model = TestData.modelify(TestData.VendorArray[0]);
+                expect(filter(model)).toBe(true);
+            });
+
+            it('excludes a point beyond 50 miles with selected product', function () {
+                var model = TestData.modelify(TestData.VendorArray[2]);
+                expect(filter(model)).toBe(false);
+            });
+
+            it('excludes a point within 50 miles and different products', function () {
+                var model = TestData.modelify(TestData.VendorArray[3]);
+                expect(filter(model)).toBe(false);
+            });
+
+        });
+
+    });
+
+});


### PR DESCRIPTION
We implemented the search util so that the vendor store data would be
sorted when we chose either a location or product. Note: this doesn't sort
the vendor store data when the user location is enabled.