### PR TITLE
Feature 4170 port search util

### DIFF
--- a/app/util/Crossfilter.js
+++ b/app/util/Crossfilter.js
@@ -1,0 +1,45 @@
+// Crossfilter.js is intended to manage any filtering on the Products
+// store that is implied by the filtering that is performed by the
+// Search util on the Vendor store.
+// 
+// Therefore:
+//
+// 1) This util should not be called outside of Search.js
+//
+// 2) This util does not maintain its own internal state via
+//    "options", it uses the products record from Search.js options.
+
+Ext.define('WhatsFresh.util.Crossfilter', {
+
+    singleton: true,
+
+    require: ['WhatsFresh.util.Search'],
+
+    constructor: function() {},
+
+    buildCrossfilterFunction: function() {
+        var Search = WhatsFresh.util.Search;
+        var selectorRecord = Search.options.product;
+        var filterable = Search.canFilterByProduct();
+
+        var filter = function(productStoreRecord) {
+            
+            if (filterable){
+                return productStoreRecord.name === selectorRecord.get('name');
+            } else return true;
+
+        };
+        return filter;
+    },
+
+    applyCrossfilterToStore: function (store) {
+        var singleton = WhatsFresh.util.Crossfilter;
+        var filterFunction = singleton.buildCrossfilterFunction();
+        var criteria = new Ext.util.Filter({
+            filterFn : filterFunction,
+            root : 'data'            
+        });
+        store.clearFilter();
+        store.filter(criteria);
+    }
+});

--- a/app/util/Geography.js
+++ b/app/util/Geography.js
@@ -1,0 +1,72 @@
+Ext.define('WhatsFresh.util.Geography', {
+
+    // Class should be used statically.
+    singleton: true,
+
+    // WolframAlpha
+    Reference: {
+        Earth: {
+            'average radius': 6367444.7,// meters
+            'oblateness': 0.0033528197// unitless
+        },
+        Units: {
+            'miles': {
+                meters: 1609.344
+            },
+            'meters': {
+                meters: 1.0
+            }
+        }
+    },
+
+    /**
+     * Calculates distance between two Earth surface coordinates.
+     * Uses haversine formula for great-circle minumum distance.
+     * DOES NOT use oblateness.
+     * DOES NOT use significant figures.
+     * From: http://www.movable-type.co.uk/scripts/latlong.html
+     * @param  {number} lat1First point's latitude.
+     * @param  {number} lng1First point's longitude.
+     * @param  {number} lat2Second point's latitude.
+     * @param  {number} lng2Second point's longitude.
+     * @return {number}Sphere arc length in meters.
+     */
+    getDistance: function (lat1, lng1, lat2, lng2) {
+        var geo= WhatsFresh.util.Geography;
+        var R= geo.Reference.Earth['average radius'];
+        var φ1= geo.degreesToRadians(lat1);
+        var φ2= geo.degreesToRadians(lat2);
+        var Δφ= geo.degreesToRadians(lat2-lat1); // φ is latitude
+        var Δλ= geo.degreesToRadians(lng2-lng1); // λ is longitude
+        var a= Math.sin(Δφ/2) * Math.sin(Δφ/2) +
+            Math.cos(φ1) * Math.cos(φ2) *
+            Math.sin(Δλ/2) * Math.sin(Δλ/2);
+        var c= 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+        var d= R * c;
+        return d;
+    },
+
+    /**
+     * Only accepts what units are defined in Reference above.
+     */
+    standardizeDistance: function (distanceRecord) {
+        var Units = WhatsFresh.util.Geography.Reference.Units;
+        return Units[distanceRecord.unit].meters * distanceRecord.value;
+    },
+
+    /* ------------------------------------------------------------------------
+       Utility and Helper Functions
+       ------------------------------------------------------------------------
+    */
+
+    // Converts Euclidean degrees into radians.
+    degreesToRadians: function (degrees) {
+        return degrees * Math.PI / 180;
+    },
+
+    // Converts Euclidean radians into degress.
+    radiansToDegrees: function (radians) {
+        return radians * 180 / Math.PI;
+    }
+
+});

--- a/app/util/Search.js
+++ b/app/util/Search.js
@@ -1,0 +1,73 @@
+Ext.define('WhatsFresh.util.Search', {
+
+    singleton: true,
+
+    requires: [],
+    
+    options: {
+        position: null,
+        distance: null,
+        location: null,
+    },
+
+    constructor: function() {},
+
+    /* ------------------------------------------------------------------------
+       Filter Definition
+       ------------------------------------------------------------------------
+    */
+
+    buildFilterFunction: function () {
+        var singleton = WhatsFresh.util.Search;
+        var Geo = WhatsFresh.util.Geography;
+        var filter = function (pointOfInterestRecord) {
+            var pos= singleton.options.position;
+            var dist= singleton.options.distance;
+            var loc= singleton.options.location;
+            var poi= pointOfInterestRecord;
+
+            // If position and distance are set, filter on those.
+            if (singleton.canFilterByDistance()) {
+                var φ1= pos.coords.latitude;
+                var λ1= pos.coords.longitude;
+                var φ2= poi.get('lat');
+                var λ2= poi.get('lng');
+                var dMax= Geo.standardizeDistance(dist);
+                var dCurr= Geo.getDistance(φ1,λ1,φ2,λ2);
+                var isNear= dMax - dCurr >= 0;
+                return isNear;
+            }
+
+            // If location is set, filter on that instead.
+            if (singleton.canFilterByLocation()) {
+                return loc.name === poi.get('city');
+            }
+
+            // Otherwise, include everything.
+            return true;
+        };
+        return filter;
+    },
+
+    applyFilterToStore: function () {
+        
+    },
+
+    /* ------------------------------------------------------------------------
+       Utility and Helper Functions
+       ------------------------------------------------------------------------
+    */
+
+    canFilterByDistance: function () {
+        var opt = this.options;
+        var hasPosition = !!opt.position && !!opt.position.coords;
+        var hasDistance = !!opt.distance && !!opt.distance.value;
+        return hasPosition && hasDistance;
+    },
+
+    canFilterByLocation: function () {
+        var opt = this.options;
+        var isValidLocation = !!opt.location && !opt.location.is_not_filterable;
+        return !this.canFilterByDistance() && isValidLocation;
+    }
+});

--- a/app/util/Search.js
+++ b/app/util/Search.js
@@ -25,9 +25,13 @@ Ext.define('WhatsFresh.util.Search', {
             var pos= singleton.options.position;
             var dist= singleton.options.distance;
             var loc= singleton.options.location;
-            
+            var prod= singleton.options.product;
+
             // Composable filters
             var hasProduct, isNear, isInCity;
+
+            // Discard placeholders
+            if (vendorStoreRecord.is_not_filterable) return false;
 
             // If position and distance are set, filter on those. If
             // not, include everything.
@@ -52,13 +56,20 @@ Ext.define('WhatsFresh.util.Search', {
 
             // If the product is set, filter. If not, include everything.
             if (singleton.canFilterByProduct()) {
-                // todo: iterate through vendor inventory and
-                // cross-filter w/products
+                var vendorProducts= vendorStoreRecord.get('products');
+
+                hasProduct= false;
+                for (var i = 0; i < vendorProducts.length; i++){
+                    if (prod.name === vendorProducts[i].name){
+                        hasProduct = true;
+                        break;
+                    }
+                }
             } else {
                 hasProduct= true;
             }
 
-            // Otherwise, include everything.
+            // Return all filters
             return isNear && isInCity && hasProduct;
         };
         return filter;

--- a/tests/jasmine-standalone/SpecRunner.html
+++ b/tests/jasmine-standalone/SpecRunner.html
@@ -11,11 +11,10 @@
   <script type="text/javascript" src="lib/jasmine-2.0.1/jasmine-html.js"></script>
   <script type="text/javascript" src="lib/jasmine-2.0.1/boot.js"></script>
 
-  <!-- ExtJS -->
+  <!-- ExtJS, Ajax mocking, and test data resources -->
   <script type="text/javascript" src="../../touch/sencha-touch-all-debug.js"></script>
-
-  <!-- include source files here... -->
   <script type="text/javascript" src="spec/javascripts/helpers/mock-ajax.js"></script>
+  <script type="text/javascript" src="spec/javascripts/helpers/test-data.js"></script>
 
   <!-- Models --> 
   <script type="text/javascript" src="../../app/model/Locations.js"></script>
@@ -31,20 +30,11 @@
   <script type="text/javascript" src="../../app/store/Vendor.js"></script>
   <script type="text/javascript" src="../../app/store/VendorInventory.js"></script>
 
-  <!-- Views -->
+  <!-- Utils -->
+  <script type="text/javascript" src="../../app/util/Search.js"></script>
 
   <!-- Controller -->
   <script type="text/javascript" src="../../app/controller/List.js"></script>
-
-  <!--
-  <script type="text/javascript" src="..\app/view/Home.js"></script>
-  <script id="microloader" type="text/javascript" src="..\.sencha/app/microloader/development.js"></script>
-  <script type="text/javascript" src="..\app/view/Detail.js"></script>
-  <script type="text/javascript" src="..\app/view/Location.js"></script>
-  <script type="text/javascript" src="..\app/controller/List.js"></script>
-  <script type="text/javascript" src="..\app.js"></script>
-  <script type="text/javascript" src="..\touch/sencha-touch-all-debug.js"></script>
-  -->
 
   <!-- include spec files here... -->
   <script type="text/javascript" src="spec/javascripts/sanitySpec.js"></script>
@@ -62,8 +52,9 @@
   <script type="text/javascript" src="spec/javascripts/store/productSpec.js"></script>
   <script type="text/javascript" src="spec/javascripts/store/vendorSpec.js"></script>
   <script type="text/javascript" src="spec/javascripts/store/vendorInventorySpec.js"></script>
- 
 
+  <!-- Util tests -->
+  <script type="text/javascript" src="spec/javascripts/util/searchSpec.js"></script>
 
 </head>
 

--- a/tests/jasmine-standalone/SpecRunner.html
+++ b/tests/jasmine-standalone/SpecRunner.html
@@ -31,6 +31,7 @@
     <script type="text/javascript" src="../../app/store/VendorInventory.js"></script>
 
     <!-- Utils -->
+    <script type="text/javascript" src="../../app/util/Crossfilter.js"></script>
     <script type="text/javascript" src="../../app/util/Geography.js"></script>
     <script type="text/javascript" src="../../app/util/Search.js"></script>
 
@@ -55,6 +56,7 @@
     <script type="text/javascript" src="spec/javascripts/store/vendorInventorySpec.js"></script>
 
     <!-- Util tests -->
+    <script type="text/javascript" src="spec/javascripts/util/crossfilterSpec.js"></script>
     <script type="text/javascript" src="spec/javascripts/util/geographySpec.js"></script>
     <script type="text/javascript" src="spec/javascripts/util/searchSpec.js"></script>
 

--- a/tests/jasmine-standalone/SpecRunner.html
+++ b/tests/jasmine-standalone/SpecRunner.html
@@ -1,63 +1,65 @@
 <!DOCTYPE HTML>
 <html>
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <title>Jasmine Spec Runner v2.0.1</title>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Jasmine Spec Runner v2.0.1</title>
 
-  <link rel="shortcut icon" type="image/png" href="lib/jasmine-2.0.1/jasmine_favicon.png">
-  <link rel="stylesheet" type="text/css" href="lib/jasmine-2.0.1/jasmine.css">
+    <link rel="shortcut icon" type="image/png" href="lib/jasmine-2.0.1/jasmine_favicon.png">
+    <link rel="stylesheet" type="text/css" href="lib/jasmine-2.0.1/jasmine.css">
 
-  <script type="text/javascript" src="lib/jasmine-2.0.1/jasmine.js"></script>
-  <script type="text/javascript" src="lib/jasmine-2.0.1/jasmine-html.js"></script>
-  <script type="text/javascript" src="lib/jasmine-2.0.1/boot.js"></script>
+    <script type="text/javascript" src="lib/jasmine-2.0.1/jasmine.js"></script>
+    <script type="text/javascript" src="lib/jasmine-2.0.1/jasmine-html.js"></script>
+    <script type="text/javascript" src="lib/jasmine-2.0.1/boot.js"></script>
 
-  <!-- ExtJS, Ajax mocking, and test data resources -->
-  <script type="text/javascript" src="../../touch/sencha-touch-all-debug.js"></script>
-  <script type="text/javascript" src="spec/javascripts/helpers/mock-ajax.js"></script>
-  <script type="text/javascript" src="spec/javascripts/helpers/test-data.js"></script>
+    <!-- ExtJS, Ajax mocking, and test data resources -->
+    <script type="text/javascript" src="../../touch/sencha-touch-all-debug.js"></script>
+    <script type="text/javascript" src="spec/javascripts/helpers/mock-ajax.js"></script>
+    <script type="text/javascript" src="spec/javascripts/helpers/test-data.js"></script>
 
-  <!-- Models --> 
-  <script type="text/javascript" src="../../app/model/Locations.js"></script>
-  <script type="text/javascript" src="../../app/model/Products.js"></script>
-  <script type="text/javascript" src="../../app/model/Vendors.js"></script>
-  <script type="text/javascript" src="../../app/model/VendorInventories.js"></script>
+    <!-- Models --> 
+    <script type="text/javascript" src="../../app/model/Locations.js"></script>
+    <script type="text/javascript" src="../../app/model/Products.js"></script>
+    <script type="text/javascript" src="../../app/model/Vendors.js"></script>
+    <script type="text/javascript" src="../../app/model/VendorInventories.js"></script>
 
-  <!-- Stores -->
-  <script type="text/javascript" src="../../app/store/Distance.js"></script>
-  <script type="text/javascript" src="../../app/store/Education.js"></script>
-  <script type="text/javascript" src="../../app/store/Location.js"></script>
-  <script type="text/javascript" src="../../app/store/Product.js"></script>
-  <script type="text/javascript" src="../../app/store/Vendor.js"></script>
-  <script type="text/javascript" src="../../app/store/VendorInventory.js"></script>
+    <!-- Stores -->
+    <script type="text/javascript" src="../../app/store/Distance.js"></script>
+    <script type="text/javascript" src="../../app/store/Education.js"></script>
+    <script type="text/javascript" src="../../app/store/Location.js"></script>
+    <script type="text/javascript" src="../../app/store/Product.js"></script>
+    <script type="text/javascript" src="../../app/store/Vendor.js"></script>
+    <script type="text/javascript" src="../../app/store/VendorInventory.js"></script>
 
-  <!-- Utils -->
-  <script type="text/javascript" src="../../app/util/Search.js"></script>
+    <!-- Utils -->
+    <script type="text/javascript" src="../../app/util/Geography.js"></script>
+    <script type="text/javascript" src="../../app/util/Search.js"></script>
 
-  <!-- Controller -->
-  <script type="text/javascript" src="../../app/controller/List.js"></script>
+    <!-- Controller -->
+    <script type="text/javascript" src="../../app/controller/List.js"></script>
 
-  <!-- include spec files here... -->
-  <script type="text/javascript" src="spec/javascripts/sanitySpec.js"></script>
-   <!-- Controller Testing Spec files -->
-  <script type="text/javascript" src="spec/javascripts/controller/listSpec.js"></script>
-  <!-- Model Testing Spec files -->
-  <script type="text/javascript" src="spec/javascripts/model/locationsSpec.js"></script>
-  <script type="text/javascript" src="spec/javascripts/model/productsSpec.js"></script>
-  <script type="text/javascript" src="spec/javascripts/model/vendorsSpec.js"></script>
-  <script type="text/javascript" src="spec/javascripts/model/vendorInventoriesSpec.js"></script>
-  <!-- Store Testing Spec files -->
-  <script type="text/javascript" src="spec/javascripts/store/distanceSpec.js"></script>
-  <script type="text/javascript" src="spec/javascripts/store/educationSpec.js"></script>
-  <script type="text/javascript" src="spec/javascripts/store/locationSpec.js"></script>
-  <script type="text/javascript" src="spec/javascripts/store/productSpec.js"></script>
-  <script type="text/javascript" src="spec/javascripts/store/vendorSpec.js"></script>
-  <script type="text/javascript" src="spec/javascripts/store/vendorInventorySpec.js"></script>
+    <!-- include spec files here... -->
+    <script type="text/javascript" src="spec/javascripts/sanitySpec.js"></script>
+    <!-- Controller Testing Spec files -->
+    <script type="text/javascript" src="spec/javascripts/controller/listSpec.js"></script>
+    <!-- Model Testing Spec files -->
+    <script type="text/javascript" src="spec/javascripts/model/locationsSpec.js"></script>
+    <script type="text/javascript" src="spec/javascripts/model/productsSpec.js"></script>
+    <script type="text/javascript" src="spec/javascripts/model/vendorsSpec.js"></script>
+    <script type="text/javascript" src="spec/javascripts/model/vendorInventoriesSpec.js"></script>
+    <!-- Store Testing Spec files -->
+    <script type="text/javascript" src="spec/javascripts/store/distanceSpec.js"></script>
+    <script type="text/javascript" src="spec/javascripts/store/educationSpec.js"></script>
+    <script type="text/javascript" src="spec/javascripts/store/locationSpec.js"></script>
+    <script type="text/javascript" src="spec/javascripts/store/productSpec.js"></script>
+    <script type="text/javascript" src="spec/javascripts/store/vendorSpec.js"></script>
+    <script type="text/javascript" src="spec/javascripts/store/vendorInventorySpec.js"></script>
 
-  <!-- Util tests -->
-  <script type="text/javascript" src="spec/javascripts/util/searchSpec.js"></script>
+    <!-- Util tests -->
+    <script type="text/javascript" src="spec/javascripts/util/geographySpec.js"></script>
+    <script type="text/javascript" src="spec/javascripts/util/searchSpec.js"></script>
 
-</head>
+  </head>
 
-<body>
-</body>
+  <body>
+  </body>
 </html>

--- a/tests/jasmine-standalone/spec/javascripts/helpers/test-data.js
+++ b/tests/jasmine-standalone/spec/javascripts/helpers/test-data.js
@@ -1,0 +1,68 @@
+// Creates global objects that contain test data.
+// This is to be kept up-to-date with the API
+
+// Assign the Global Variable
+window.TestData = {};
+
+// Please don't judge me.
+// This function adds a get() method to the object to
+// make it look like a store model/record.
+TestData.modelify = function (obj) {
+    obj = JSON.parse(JSON.stringify(obj));
+    obj.get = function (key) { return this[key]; };
+    return obj;
+};
+
+TestData.VendorArray = [
+    {
+        city: 'Newport',
+        updated: true,
+        description: 'a place with stuff',
+        zip: '97523',
+        created: true,
+        ext: false,
+        location_description: 'its a place with a thing',
+        lng: '45',
+        lat: '45',
+        email: 'user@email.com',
+        website: 'site.com',
+        phone: '555-555-5555',
+        state: 'OR',
+        street: 'corner street',
+        products: ['fish', 'shellfish', 'more fish'],
+        contact_name: 'John Doe',
+        story: 'see other side',
+        name: 'fish place'
+        },
+    {
+        city: 'Coos Bay',
+        updated: false,
+        description: 'stuff',
+        zip: '97420',
+        created: true,
+        ext: false,
+        location_description: 'its a place with a thing2',
+        lng: '47',
+        lat: '47',
+        email: 'user@email.com2',
+        website: 'site.com2',
+        phone: '555-555-2222',
+        state: 'OR',
+        street: 'corner street2',
+        products: ['fish', 'shellfish', '2'],
+        contact_name: 'J.D. Smith',
+        story: 'none',
+        name: 'fishy'
+        }
+];
+
+TestData.LocationArray = [
+    {
+        location: 1,
+        name: 'Newport'
+        },
+    {
+        location: 2,
+        name: 'Coos Bay'
+        }
+];

--- a/tests/jasmine-standalone/spec/javascripts/helpers/test-data.js
+++ b/tests/jasmine-standalone/spec/javascripts/helpers/test-data.js
@@ -22,17 +22,27 @@ TestData.VendorArray = [
         created: true,
         ext: false,
         location_description: 'its a place with a thing',
-        lng: '45',
-        lat: '45',
+        lat: '44.0',
+        lng: '120.0',
         email: 'user@email.com',
         website: 'site.com',
         phone: '555-555-5555',
         state: 'OR',
         street: 'corner street',
-        products: ['fish', 'shellfish', 'more fish'],
+        products: [
+            {
+                name : 'One Fish',
+                preparation : 'Live',
+            },
+            {
+                name : 'Two Fish',
+                preparation : 'Filet'
+            }            
+        ],
         contact_name: 'John Doe',
         story: 'see other side',
-        name: 'fish place'
+        name: 'fish place',
+        is_not_filterable: false
         },
     {
         city: 'Coos Bay',
@@ -42,18 +52,97 @@ TestData.VendorArray = [
         created: true,
         ext: false,
         location_description: 'its a place with a thing2',
-        lng: '47',
-        lat: '47',
+        lat: '44.0',
+        lng: '121.0',
         email: 'user@email.com2',
         website: 'site.com2',
         phone: '555-555-2222',
         state: 'OR',
         street: 'corner street2',
-        products: ['fish', 'shellfish', '2'],
+        products: [
+            {
+                name : 'Red Fish',
+                preparation : 'Dried'        
+            },
+            {
+                name : 'Blue Fish',
+                preparation : 'Frozen'        
+            }
+        ],
         contact_name: 'J.D. Smith',
         story: 'none',
-        name: 'fishy'
-        }
+        name: 'fishy',
+        is_not_filterable: false
+        },
+    {
+        city: 'Coos Bay',
+        updated: false,
+        description: 'stuff',
+        zip: '97420',
+        created: true,
+        ext: false,
+        location_description: 'its a place with a thing2',
+        lat: '45.0',
+        lng: '121.0',
+        email: 'user@email.com2',
+        website: 'site.com2',
+        phone: '555-555-2222',
+        state: 'OR',
+        street: 'corner street2',
+        products: [
+            {
+                name : 'One Fish',
+                preparation : 'Live',
+            },
+            {
+                name : 'Two Fish',
+                preparation : 'Filet'
+            },
+            {
+                name : 'Red Fish',
+                preparation : 'Dried'        
+            },
+            {
+                name : 'Blue Fish',
+                preparation : 'Frozen'        
+            }
+        ],
+        contact_name: 'J.D. Smith',
+        story: 'none',
+        name: 'Test Store',
+        is_not_filterable: false
+        },
+    {
+        city: 'Newport',
+        updated: false,
+        description: 'stuff',
+        zip: '97420',
+        created: true,
+        ext: false,
+        location_description: 'A test store with no inventory with the name: Newport',
+        lat: '45.0',
+        lng: '121.0',
+        email: 'user@email.com2',
+        website: 'site.com2',
+        phone: '555-555-2222',
+        state: 'OR',
+        street: 'corner street2',
+        products: [
+            {
+                name : 'Blue Fish',
+                preparation : 'Frozen'        
+            }
+        ],
+        contact_name: 'J.D. Smith',
+        story: 'none',
+        name: 'Not Actually In Newport',
+        is_not_filterable: false
+        },
+    {
+        name: '--Not Filterable--',
+        description: 'A test datum simulating a label/placeholder',
+        is_not_filterable: true
+    }
 ];
 
 TestData.LocationArray = [
@@ -65,4 +154,23 @@ TestData.LocationArray = [
         location: 2,
         name: 'Coos Bay'
         }
+];
+
+TestData.ProductArray = [
+    {
+        name : 'One Fish',
+        preparation : 'Live',
+    },
+    {
+        name : 'Two Fish',
+        preparation : 'Filet'
+    },
+    {
+        name : 'Red Fish',
+        preparation : 'Dried'        
+    },
+    {
+        name : 'Blue Fish',
+        preparation : 'Frozen'        
+    }
 ];

--- a/tests/jasmine-standalone/spec/javascripts/store/distanceSpec.js
+++ b/tests/jasmine-standalone/spec/javascripts/store/distanceSpec.js
@@ -52,7 +52,7 @@ describe('WhatsFresh.store.Distance',function() {
         expect(store.data.items[10].data.val).toEqual(10);
     });
     it('Is populated with distance data', function(){
-        expect(store.data.items{11].data.val).toEqual(5);
+        expect(store.data.items[11].data.val).toEqual(5);
     });
 
 });

--- a/tests/jasmine-standalone/spec/javascripts/util/crossfilterSpec.js
+++ b/tests/jasmine-standalone/spec/javascripts/util/crossfilterSpec.js
@@ -1,0 +1,104 @@
+describe('WhatsFresh.util.Crossfilter', function() {
+
+    Ext.require('WhatsFresh.util.Crossfilter');
+
+/*
+  Should be implemented as a Jasmine Spy
+
+    var SearchUtil;
+    var SearchUtilStub = Ext.define('SearchUtilStub',{
+            options : {
+                product : null
+            },
+            canFilterByProduct : function(){
+                return false;
+            }
+        });
+
+
+    beforeEach(function() {
+        // Stub out the Search util
+        SearchUtil = WhatsFresh.util.Search;
+        WhatsFresh.util.Search = Ext.create(SearchUtilStub);
+    });
+
+    afterEach(function() {
+        // Restore Search util
+        WhatsFresh.util.Search.destroy();
+        WhatsFresh.util.Search = SearchUtil;
+    });
+
+*/
+
+    it('exists as a global singleton', function() {
+        expect(WhatsFresh.util.Crossfilter).toBeDefined();
+    });
+
+    it('can find search util options from the test harness', function() {
+        expect(WhatsFresh.util.Search).toBeDefined();
+        expect(WhatsFresh.util.Search.options.product).toBeDefined();
+        expect(WhatsFresh.util.Search.options.product).toBeNull();
+    });
+
+    it('can create a filter for the product store', function() {
+        var Crossfilter = WhatsFresh.util.Crossfilter;
+        expect(Crossfilter.buildCrossfilterFunction).toBeDefined();
+        var filter = Crossfilter.buildCrossfilterFunction();
+        expect(filter).toBeDefined();
+    });
+
+    describe('buildFilterFunction', function() {
+
+        var Search      = WhatsFresh.util.Search;
+        var Crossfilter = WhatsFresh.util.Crossfilter;
+        var filter;
+
+        describe('when product is not set', function() {
+
+            // Before single test:
+            Search.options.product = null;
+            spyOn(Search, 'canFilterByProduct').and.returnValue(false);
+            filter = Crossfilter.buildCrossfilterFunction();
+
+            it('includes any product', function() {
+                var anyProduct = TestData.modelify(TestData.ProductArray[0]);
+                expect(filter(anyProduct)).toBe(true);
+            });
+
+        });
+
+        describe('when product is set', function() {
+            
+            beforeEach(function() {
+
+                // Set up stub object
+                Search.options.product = TestData.modelify(
+                    {
+                        name : 'One Fish'
+                    }
+                );
+                spyOn(Search, 'canFilterByProduct').and.returnValue(true);
+
+                filter = Crossfilter.buildCrossfilterFunction();
+            });
+
+            afterEach(function() {
+                // Clean up stub
+                Search.options.product = null;
+            });
+
+            it('includes products with matching names', function() {
+                var model = TestData.modelify(TestData.ProductArray[0]);
+                expect(filter(model)).toBe(true);
+            });
+
+            it('excludes products without matching names', function() {
+                var model = TestData.modelify(TestData.ProductArray[1]);
+                expect(filter(TestData.ProductArray[1])).toBe(false);
+            });
+
+        });
+
+    });
+    
+});

--- a/tests/jasmine-standalone/spec/javascripts/util/geographySpec.js
+++ b/tests/jasmine-standalone/spec/javascripts/util/geographySpec.js
@@ -1,0 +1,23 @@
+describe('WhatsFresh.util.Geography', function () {
+
+    Ext.require('WhatsFresh.util.Geography');
+    /* global WhatsFresh */
+
+    it('exists as a global singleton', function() {
+        expect(WhatsFresh.util.Geography).toBeDefined();
+        });
+
+    describe('getDistance()', function () {
+
+        it('calculates distance between points accurate to 100m', function () {
+            var φ1= 44.0;
+            var λ1= 120.0;
+            var φ2= 44.0;
+            var λ2= 121.0;
+            var d = WhatsFresh.util.Geography.getDistance(φ1,λ1,φ2,λ2);
+            expect(Math.abs(79990 - d)).toBeLessThan(100);
+            });
+
+        });
+
+});

--- a/tests/jasmine-standalone/spec/javascripts/util/searchSpec.js
+++ b/tests/jasmine-standalone/spec/javascripts/util/searchSpec.js
@@ -12,12 +12,14 @@ describe('WhatsFresh.util.Search', function () {
         expect(WhatsFresh.util.Search.options.position).toBeNull();
         expect(WhatsFresh.util.Search.options.distance).toBeNull();
         expect(WhatsFresh.util.Search.options.location).toBeNull();
+        expect(WhatsFresh.util.Search.options.product).toBeNull();
         });
 
     it('has filter-by logic functions', function() {
         var Search = WhatsFresh.util.Search;
         expect(Search.canFilterByDistance).toBeDefined();
         expect(Search.canFilterByLocation).toBeDefined();
+        expect(Search.canFilterByProduct).toBeDefined();
         });
 
     it('can create a store-filtering function', function() {
@@ -37,6 +39,7 @@ describe('WhatsFresh.util.Search', function () {
             Search.options.position = null;
             Search.options.distance = null;
             Search.options.location = null;
+            Search.options.product  = null;
             // These may be overridden by testcase beforeEach
             });
 
@@ -50,15 +53,21 @@ describe('WhatsFresh.util.Search', function () {
                 expect(Search.canFilterByLocation()).toBe(false);
                 });
 
-            it('includes any point of interest', function() {
+            it('includes any vendor', function() {
                 var filter = Search.buildFilterFunction();
-                var anyPOI = TestData.PointOfInterestArray[0];
-                expect(filter(anyPOI)).toBe(true);
+                var anyVendor = TestData.VendorArray[0];
+                expect(filter(anyVendor)).toBe(true);
                 });
+
+            it('includes any product', function() {
+                var filter = Search.buildFilterFunction();
+                var anyProduct = TestData.VendorArray[0];
+                expect(filter(anyProduct)).toBe(true);
+            });
 
             });
 
-        describe('where position and distance are set', function () {
+        describe('where position and distance are set and product is not set', function () {
 
             var filter;
 
@@ -89,17 +98,17 @@ describe('WhatsFresh.util.Search', function () {
                 });
 
             it('includes a point within 50 miles', function () {
-                var model = TestData.modelify(TestData.PointOfInterestArray[0]);
+                var model = TestData.modelify(TestData.VendorArray[0]);
                 expect(filter(model)).toBe(true);
                 });
 
             it('includes a point still within 50 miles', function () {
-                var model = TestData.modelify(TestData.PointOfInterestArray[1]);
+                var model = TestData.modelify(TestData.VendorArray[1]);
                 expect(filter(model)).toBe(true);
                 });
 
             it('excludes a point beyond 50 miles', function () {
-                var model = TestData.modelify(TestData.PointOfInterestArray[2]);
+                var model = TestData.modelify(TestData.VendorArray[2]);
                 expect(filter(model)).toBe(false);
                 });
 
@@ -127,17 +136,17 @@ describe('WhatsFresh.util.Search', function () {
                 });
 
             it('includes a point with same city name', function () {
-                var model = TestData.modelify(TestData.PointOfInterestArray[2]);
+                var model = TestData.modelify(TestData.VendorArray[2]);
                 expect(filter(model)).toBe(true);
                 });
 
             it('excludes a point with different city name', function () {
-                var model = TestData.modelify(TestData.PointOfInterestArray[1]);
+                var model = TestData.modelify(TestData.VendorArray[1]);
                 expect(filter(model)).toBe(false);
                 });
 
             it('excludes a point with no city name', function () {
-                var model = TestData.modelify(TestData.PointOfInterestArray[0]);
+                var model = TestData.modelify(TestData.VendorArray[0]);
                 expect(filter(model)).toBe(false);
                 });
 
@@ -175,12 +184,12 @@ describe('WhatsFresh.util.Search', function () {
                 });
 
             it('includes a point within 50 miles with no city', function () {
-                var model = TestData.modelify(TestData.PointOfInterestArray[0]);
+                var model = TestData.modelify(TestData.VendorArray[0]);
                 expect(filter(model)).toBe(true);
                 });
 
             it('excludes a point beyond 50 miles with same city', function () {
-                var model = TestData.modelify(TestData.PointOfInterestArray[2]);
+                var model = TestData.modelify(TestData.VendorArray[2]);
                 expect(filter(model)).toBe(false);
                 });
 

--- a/tests/jasmine-standalone/spec/javascripts/util/searchSpec.js
+++ b/tests/jasmine-standalone/spec/javascripts/util/searchSpec.js
@@ -5,7 +5,7 @@ describe('WhatsFresh.util.Search', function () {
 
     it('exists as a global singleton', function() {
         expect(WhatsFresh.util.Search).toBeDefined();
-        });
+    });
 
     it('has options that are null by default', function() {
         expect(WhatsFresh.util.Search.options).toBeDefined();
@@ -13,21 +13,21 @@ describe('WhatsFresh.util.Search', function () {
         expect(WhatsFresh.util.Search.options.distance).toBeNull();
         expect(WhatsFresh.util.Search.options.location).toBeNull();
         expect(WhatsFresh.util.Search.options.product).toBeNull();
-        });
+    });
 
     it('has filter-by logic functions', function() {
         var Search = WhatsFresh.util.Search;
         expect(Search.canFilterByDistance).toBeDefined();
         expect(Search.canFilterByLocation).toBeDefined();
         expect(Search.canFilterByProduct).toBeDefined();
-        });
+    });
 
     it('can create a store-filtering function', function() {
         var Search = WhatsFresh.util.Search;
         expect(Search.buildFilterFunction).toBeDefined();
         var filter = Search.buildFilterFunction();
         expect(filter).toBeDefined();
-        });
+    });
 
     describe('buildFilterFunction()', function () {
 
@@ -41,31 +41,29 @@ describe('WhatsFresh.util.Search', function () {
             Search.options.location = null;
             Search.options.product  = null;
             // These may be overridden by testcase beforeEach
-            });
+        });
 
         describe('where all options are null', function () {
 
             it('cannot filter-by distance', function() {
                 expect(Search.canFilterByDistance()).toBe(false);
-                });
+            });
 
             it('cannot filter-by location', function() {
                 expect(Search.canFilterByLocation()).toBe(false);
-                });
+            });
+
+            it('cannot filter-by product', function() {
+                expect(Search.canFilterByProduct()).toBe(false);
+            });
 
             it('includes any vendor', function() {
                 var filter = Search.buildFilterFunction();
                 var anyVendor = TestData.VendorArray[0];
                 expect(filter(anyVendor)).toBe(true);
-                });
-
-            it('includes any product', function() {
-                var filter = Search.buildFilterFunction();
-                var anyProduct = TestData.VendorArray[0];
-                expect(filter(anyProduct)).toBe(true);
             });
 
-            });
+        });
 
         describe('where position and distance are set and product is not set', function () {
 
@@ -76,83 +74,91 @@ describe('WhatsFresh.util.Search', function () {
                     coords: {
                         latitude: 44.0,
                         longitude: 120.0
-                        }
-                    };
+                    }
+                };
                 Search.options.distance = {
                     value: 50,
                     unit: 'miles'
-                    };
+                };
                 filter = Search.buildFilterFunction();
-                });
+            });
 
             afterEach(function () {
                 filter = null;
-                });
+            });
 
             it('can filter-by distance', function () {
                 expect(Search.canFilterByDistance()).toBe(true);
-                });
+            });
 
             it('cannot filter-by location', function () {
                 expect(Search.canFilterByLocation()).toBe(false);
-                });
+            });
+
+            it('cannot filter-by product', function() {
+                expect(Search.canFilterByProduct()).toBe(false);
+            });
 
             it('includes a point within 50 miles', function () {
                 var model = TestData.modelify(TestData.VendorArray[0]);
                 expect(filter(model)).toBe(true);
-                });
+            });
 
             it('includes a point still within 50 miles', function () {
                 var model = TestData.modelify(TestData.VendorArray[1]);
                 expect(filter(model)).toBe(true);
-                });
+            });
 
             it('excludes a point beyond 50 miles', function () {
                 var model = TestData.modelify(TestData.VendorArray[2]);
                 expect(filter(model)).toBe(false);
-                });
-
             });
 
-        describe('where location only is set', function () {
+        });
+
+        describe('where location is set and product is not set', function () {
 
             var filter;
 
             beforeEach(function () {
                 Search.options.location = TestData.LocationArray[0];
                 filter = Search.buildFilterFunction();
-                });
+            });
 
             afterEach(function () {
                 filter = null;
-                });
+            });
 
             it('cannot filter-by distance', function () {
                 expect(Search.canFilterByDistance()).toBe(false);
-                });
+            });
 
             it('can filter-by location', function () {
                 expect(Search.canFilterByLocation()).toBe(true);
-                });
+            });
+
+            it('cannot filter-by product', function() {
+                expect(Search.canFilterByProduct()).toBe(false);
+            });
 
             it('includes a point with same city name', function () {
-                var model = TestData.modelify(TestData.VendorArray[2]);
+                var model = TestData.modelify(TestData.VendorArray[0]);
                 expect(filter(model)).toBe(true);
-                });
+            });
 
             it('excludes a point with different city name', function () {
                 var model = TestData.modelify(TestData.VendorArray[1]);
                 expect(filter(model)).toBe(false);
-                });
-
-            it('excludes a point with no city name', function () {
-                var model = TestData.modelify(TestData.VendorArray[0]);
-                expect(filter(model)).toBe(false);
-                });
-
             });
 
-        describe('where all options are set', function () {
+            it('excludes a point with no city name', function () {
+                var model = TestData.modelify(TestData.VendorArray[2]);
+                expect(filter(model)).toBe(false);
+            });
+
+        });
+
+        describe('where position and location are set, but product is not', function () {
 
             var filter;
 
@@ -161,40 +167,223 @@ describe('WhatsFresh.util.Search', function () {
                     coords: {
                         latitude: 44.0,
                         longitude: 120.0
-                        }
-                    };
+                    }
+                };
                 Search.options.distance = {
                     value: 50,
                     unit: 'miles'
-                    };
+                };
                 Search.options.location = TestData.LocationArray[0];
                 filter = Search.buildFilterFunction();
-                });
+            });
 
             afterEach(function () {
                 filter = null;
-                });
+            });
 
             it('can filter-by distance', function () {
                 expect(Search.canFilterByDistance()).toBe(true);
-                });
+            });
 
             it('cannot filter-by location', function () {
                 expect(Search.canFilterByLocation()).toBe(false);
-                });
+            });
+
+            it('cannot filter-by product', function() {
+                expect(Search.canFilterByProduct()).toBe(false);
+            });
 
             it('includes a point within 50 miles with no city', function () {
                 var model = TestData.modelify(TestData.VendorArray[0]);
                 expect(filter(model)).toBe(true);
-                });
+            });
 
             it('excludes a point beyond 50 miles with same city', function () {
                 var model = TestData.modelify(TestData.VendorArray[2]);
                 expect(filter(model)).toBe(false);
-                });
-
             });
 
         });
+
+        describe('when only product is set', function () {
+            
+            var filter;
+
+            beforeEach( function (){
+                Search.options.product= TestData.ProductArray[0];
+                filter= Search.buildFilterFunction();
+            });
+
+            afterEach( function (){
+                filter= null;
+            });
+
+            it('cannot filter-by distance', function () {
+                expect(Search.canFilterByDistance()).toBe(false);
+            });
+
+            it('cannot filter-by location', function () {
+                expect(Search.canFilterByLocation()).toBe(false);
+            });
+
+            it('can filter-by product', function() {
+                expect(Search.canFilterByProduct()).toBe(true);
+            });
+
+            it('includes a vendor with the given product', function () {
+                var model= TestData.modelify(TestData.VendorArray[0]);
+                expect(filter(model)).toBe(true);
+            });
+
+            it('excludes a vendor not carrying the given product', function () {
+                var model= TestData.modelify(TestData.VendorArray[1]);
+                expect(filter(model)).toBe(false);
+            });
+
+        });
+
+        describe('when position and distance are set and product is set.', function () {
+
+            var filter;
+
+            beforeEach( function (){
+                Search.options.position = {
+                    coords: {
+                        latitude: 44.0,
+                        longitude: 120.0
+                    }
+                };
+                Search.options.distance = {
+                    value: 50,
+                    unit: 'miles'
+                };
+                Search.options.product= TestData.ProductArray[0];
+                filter= Search.buildFilterFunction();
+            });
+
+            afterEach( function (){
+                filter= null;
+            });
+
+            it('can filter-by distance', function () {
+                expect(Search.canFilterByDistance()).toBe(true);
+            });
+
+            it('cannot filter-by location', function () {
+                expect(Search.canFilterByLocation()).toBe(false);
+            });
+
+            it('can filter-by product', function() {
+                expect(Search.canFilterByProduct()).toBe(true);
+            });
+
+            it('includes a point within 50 miles with selected product', function () {
+                var model = TestData.modelify(TestData.VendorArray[0]);
+                expect(filter(model)).toBe(true);
+            });
+
+            it('excludes a point beyond 50 miles with selected product', function () {
+                var model = TestData.modelify(TestData.VendorArray[2]);
+                expect(filter(model)).toBe(false);
+            });
+
+            it('excludes a point within 50 miles and different products', function () {
+                var model = TestData.modelify(TestData.VendorArray[3]);
+                expect(filter(model)).toBe(false);
+            });
+            
+        });
+
+        describe('When location is set and product is set', function () {
+
+            var filter;
+
+            beforeEach( function (){
+                Search.options.location = TestData.LocationArray[0];
+                Search.options.product= TestData.ProductArray[0];
+                filter= Search.buildFilterFunction();
+            });
+
+            afterEach( function (){
+                filter= null;
+            });
+
+            it('cannot filter-by distance', function () {
+                expect(Search.canFilterByDistance()).toBe(false);
+            });
+
+            it('can filter-by location', function () {
+                expect(Search.canFilterByLocation()).toBe(true);
+            });
+
+            it('can filter-by product', function() {
+                expect(Search.canFilterByProduct()).toBe(true);
+            });
+
+            it('includes a point with same city name and selected product', function () {
+                var model = TestData.modelify(TestData.VendorArray[0]);
+                expect(filter(model)).toBe(true);
+            });
+
+            it('excludes a point with different city name and selected product', function () {
+                var model = TestData.modelify(TestData.VendorArray[2]);
+                expect(filter(model)).toBe(false);
+            });
+
+            it('excludes a point with same city name and different products', function () {
+                var model = TestData.modelify(TestData.VendorArray[3]);
+                expect(filter(model)).toBe(false);
+            });
+
+        });
+
+        describe('When all options are set', function () {
+
+            var filter;
+
+            beforeEach( function (){
+                Search.options.position = {
+                    coords: {
+                        latitude: 44.0,
+                        longitude: 120.0
+                    }
+                };
+                Search.options.distance = {
+                    value: 50,
+                    unit: 'miles'
+                };
+                Search.options.location = TestData.LocationArray[0];
+                Search.options.product= TestData.ProductArray[0];
+                filter= Search.buildFilterFunction();
+            });
+
+            afterEach( function (){
+                filter= null;
+            });
+
+            it('filter behaves as though distance and product are set', function() {
+                expect(Search.canFilterByDistance()).toBe(true);
+                expect(Search.canFilterByLocation()).toBe(false);
+                expect(Search.canFilterByProduct()).toBe(true);
+            });
+
+            it('includes a point within 50 miles with selected product', function () {
+                var model = TestData.modelify(TestData.VendorArray[0]);
+                expect(filter(model)).toBe(true);
+            });
+
+            it('excludes a point beyond 50 miles with selected product', function () {
+                var model = TestData.modelify(TestData.VendorArray[2]);
+                expect(filter(model)).toBe(false);
+            });
+
+            it('excludes a point within 50 miles and different products', function () {
+                var model = TestData.modelify(TestData.VendorArray[3]);
+                expect(filter(model)).toBe(false);
+            });
+
+        });
+
+    });
 
 });

--- a/tests/jasmine-standalone/spec/javascripts/util/searchSpec.js
+++ b/tests/jasmine-standalone/spec/javascripts/util/searchSpec.js
@@ -1,0 +1,191 @@
+describe('WhatsFresh.util.Search', function () {
+
+    Ext.require('WhatsFresh.util.Search');
+    /* global WhatsFresh */
+
+    it('exists as a global singleton', function() {
+        expect(WhatsFresh.util.Search).toBeDefined();
+        });
+
+    it('has options that are null by default', function() {
+        expect(WhatsFresh.util.Search.options).toBeDefined();
+        expect(WhatsFresh.util.Search.options.position).toBeNull();
+        expect(WhatsFresh.util.Search.options.distance).toBeNull();
+        expect(WhatsFresh.util.Search.options.location).toBeNull();
+        });
+
+    it('has filter-by logic functions', function() {
+        var Search = WhatsFresh.util.Search;
+        expect(Search.canFilterByDistance).toBeDefined();
+        expect(Search.canFilterByLocation).toBeDefined();
+        });
+
+    it('can create a store-filtering function', function() {
+        var Search = WhatsFresh.util.Search;
+        expect(Search.buildFilterFunction).toBeDefined();
+        var filter = Search.buildFilterFunction();
+        expect(filter).toBeDefined();
+        });
+
+    describe('buildFilterFunction()', function () {
+
+        var Search = WhatsFresh.util.Search;
+
+        beforeEach(function () {
+            // Reset the properties on the singleton.
+            // Prevents cross-test pollution.
+            Search.options.position = null;
+            Search.options.distance = null;
+            Search.options.location = null;
+            // These may be overridden by testcase beforeEach
+            });
+
+        describe('where all options are null', function () {
+
+            it('cannot filter-by distance', function() {
+                expect(Search.canFilterByDistance()).toBe(false);
+                });
+
+            it('cannot filter-by location', function() {
+                expect(Search.canFilterByLocation()).toBe(false);
+                });
+
+            it('includes any point of interest', function() {
+                var filter = Search.buildFilterFunction();
+                var anyPOI = TestData.PointOfInterestArray[0];
+                expect(filter(anyPOI)).toBe(true);
+                });
+
+            });
+
+        describe('where position and distance are set', function () {
+
+            var filter;
+
+            beforeEach(function () {
+                Search.options.position = {
+                    coords: {
+                        latitude: 44.0,
+                        longitude: 120.0
+                        }
+                    };
+                Search.options.distance = {
+                    value: 50,
+                    unit: 'miles'
+                    };
+                filter = Search.buildFilterFunction();
+                });
+
+            afterEach(function () {
+                filter = null;
+                });
+
+            it('can filter-by distance', function () {
+                expect(Search.canFilterByDistance()).toBe(true);
+                });
+
+            it('cannot filter-by location', function () {
+                expect(Search.canFilterByLocation()).toBe(false);
+                });
+
+            it('includes a point within 50 miles', function () {
+                var model = TestData.modelify(TestData.PointOfInterestArray[0]);
+                expect(filter(model)).toBe(true);
+                });
+
+            it('includes a point still within 50 miles', function () {
+                var model = TestData.modelify(TestData.PointOfInterestArray[1]);
+                expect(filter(model)).toBe(true);
+                });
+
+            it('excludes a point beyond 50 miles', function () {
+                var model = TestData.modelify(TestData.PointOfInterestArray[2]);
+                expect(filter(model)).toBe(false);
+                });
+
+            });
+
+        describe('where location only is set', function () {
+
+            var filter;
+
+            beforeEach(function () {
+                Search.options.location = TestData.LocationArray[0];
+                filter = Search.buildFilterFunction();
+                });
+
+            afterEach(function () {
+                filter = null;
+                });
+
+            it('cannot filter-by distance', function () {
+                expect(Search.canFilterByDistance()).toBe(false);
+                });
+
+            it('can filter-by location', function () {
+                expect(Search.canFilterByLocation()).toBe(true);
+                });
+
+            it('includes a point with same city name', function () {
+                var model = TestData.modelify(TestData.PointOfInterestArray[2]);
+                expect(filter(model)).toBe(true);
+                });
+
+            it('excludes a point with different city name', function () {
+                var model = TestData.modelify(TestData.PointOfInterestArray[1]);
+                expect(filter(model)).toBe(false);
+                });
+
+            it('excludes a point with no city name', function () {
+                var model = TestData.modelify(TestData.PointOfInterestArray[0]);
+                expect(filter(model)).toBe(false);
+                });
+
+            });
+
+        describe('where all options are set', function () {
+
+            var filter;
+
+            beforeEach(function () {
+                Search.options.position = {
+                    coords: {
+                        latitude: 44.0,
+                        longitude: 120.0
+                        }
+                    };
+                Search.options.distance = {
+                    value: 50,
+                    unit: 'miles'
+                    };
+                Search.options.location = TestData.LocationArray[0];
+                filter = Search.buildFilterFunction();
+                });
+
+            afterEach(function () {
+                filter = null;
+                });
+
+            it('can filter-by distance', function () {
+                expect(Search.canFilterByDistance()).toBe(true);
+                });
+
+            it('cannot filter-by location', function () {
+                expect(Search.canFilterByLocation()).toBe(false);
+                });
+
+            it('includes a point within 50 miles with no city', function () {
+                var model = TestData.modelify(TestData.PointOfInterestArray[0]);
+                expect(filter(model)).toBe(true);
+                });
+
+            it('excludes a point beyond 50 miles with same city', function () {
+                var model = TestData.modelify(TestData.PointOfInterestArray[2]);
+                expect(filter(model)).toBe(false);
+                });
+
+            });
+
+        });
+
+});


### PR DESCRIPTION
This branch resolves the task of porting all search functionality from the working-waterfronts-mobile project to whats-fresh-mobile:

- Filtering a vendor store by device location and radius
- Filtering a vendor store by a specified city
- Filtering a vendor store and filtering a product store by a product

This branch (and this task) do not address the task of integrating these utils into the app's execution path.