### PR TITLE
Remove extra buttons and format (Rebased)

### DIFF
--- a/app/controller/List.js
+++ b/app/controller/List.js
@@ -35,7 +35,6 @@ Ext.define('WhatsFresh.controller.List', {
 			},
 			listView: {
 				viewBackHomeCommand: 'onViewBackHomeCommand',
-				viewDetailCommand: 'onViewDetailCommand',
 				viewLpageListHighlightCommand: 'onViewLpageListHighlightCommand',
 				viewLpageListItemCommand: 'onViewLpageListItemCommand'
 			},
@@ -77,17 +76,17 @@ Ext.define('WhatsFresh.controller.List', {
 	// stuff	######################################################################################	HOME
     onSetUseLocation: function(newToggleValue){
         var ctrl = this;
-	if(newToggleValue){
-	    // This updates the user's location and how far from their location they would like to search for vendors/products
-	    Ext.device.Geolocation.watchPosition({
-                scope : ctrl,
-		frequency : 10000, // Update every 10 seconds
-		callback: ctrl.devicePositionCallback,
-		failure: ctrl.devicePositionFailure
-	    });
-	}else{
-	    Ext.device.Geolocation.clearWatch();
-	}
+		if(newToggleValue){
+		    // This updates the user's location and how far from their location they would like to search for vendors/products
+		    Ext.device.Geolocation.watchPosition({
+	                scope : ctrl,
+			frequency : 10000, // Update every 10 seconds
+			callback: ctrl.devicePositionCallback,
+			failure: ctrl.devicePositionFailure
+		    });
+		}else{
+		    Ext.device.Geolocation.clearWatch();
+		}
     },
     devicePositionCallback: function(position) {
         // todo: 
@@ -369,11 +368,7 @@ Ext.define('WhatsFresh.controller.List', {
 		var listItems = this.getListView();
 		listItems._items.items[2].deselect(listItems._items.items[2].selected.items[0]);		
 		Ext.Viewport.animateActiveItem(this.getHomeView(), this.slideRightTransition);
-	},
-	onViewDetailCommand: function(){
-		console.log('In controller(list): View Detail Page Button');
-		Ext.Viewport.animateActiveItem(this.getDetailView(), this.slideLeftTransition);
-	},		
+	},	
 	// declareMap markers and infowindows as well as functions for the listview map
 	addMapMarkers: function(){
 		var self = this; // important to get the correct data to the viewport
@@ -619,8 +614,6 @@ Ext.define('WhatsFresh.controller.List', {
 		// console.log(this);
 		// console.log(productdetailView._items.items[1]._data);
 		// console.log(detailView._items.items[1]._data);
-		Ext.ComponentQuery.query('toolbar[itemId=productdetailPageToolbar]')[0].setTitle(index.data.preparation + ' ' + index.data.name);
-		Ext.ComponentQuery.query('toolbar[itemId=detailPageToolbar]')[0].setTitle(index.data.name);
 		// Trying to pass product data from selected vendor to new store, so that we
 		// can use the new store to correctly use tpl print to make selectable list 
 		// items of each unique product.
@@ -837,7 +830,6 @@ Ext.define('WhatsFresh.controller.List', {
 					// console.log(productdetailView.getAt(1)._data);  
 				}
 			}
-			Ext.ComponentQuery.query('toolbar[itemId=productdetailPageToolbar]')[0].setTitle(index.data.preparation + ' ' + index.data.name);
 			if(WhatsFresh.backFlag === 0){
 				WhatsFresh.path[WhatsFresh.pcount] = 'productdetail';
 				WhatsFresh.pvalue[WhatsFresh.pcount] = index;
@@ -886,7 +878,6 @@ Ext.define('WhatsFresh.controller.List', {
 				}
 			}
 			// Sets the title of the header on detail page
-			Ext.ComponentQuery.query('toolbar[itemId=detailPageToolbar]')[0].setTitle(index.data.name);
 			WhatsFresh.statmap.setSrc( this.buildStaticMap(detailView.items.items[1]._data) );
 			if(WhatsFresh.backFlag === 0){
 
@@ -943,10 +934,6 @@ Ext.define('WhatsFresh.controller.List', {
 		}
 		// Ext.Viewport.animateActiveItem(this.getDetailView(), this.slideRightTransition);
 	},
-	onViewSpecificCommand: function(){
-		console.log('In controller(info): View Specific Page Button');
-		Ext.Viewport.animateActiveItem(this.getSpecificView(), this.slideLeftTransition);
-	},	
 	onViewIpageListItemCommand: function(record, list, index){
 		console.log('In controller(info): Selected');
 		// Ext.Msg.alert(index.data.listItem, 'This is the stuff I selected.');

--- a/app/view/Detail.js
+++ b/app/view/Detail.js
@@ -17,21 +17,15 @@ Ext.define('WhatsFresh.view.Detail', {
 					{
 						xtype: 'button',
 						ui: 'action',
-						text: 'back',
-						itemId: 'backListButton'
-					},
-					{
-						xtype: 'button',
-						ui: 'action',
-						text: 'Info',
-						itemId: 'infoButton'
-					},
-					{
-						xtype: 'button',
-						ui: 'action',
 						// text: 'Home',
 						iconCls: 'home',
 						itemId: 'backHomeButton'
+					},
+					{
+						xtype: 'button',
+						ui: 'action',
+						text: 'back',
+						itemId: 'backListButton'
 					}
 				]
 			},
@@ -72,11 +66,6 @@ Ext.define('WhatsFresh.view.Detail', {
 				fn: 'onBackButtonTap'
 			},
 			{
-				delegate: '#infoButton',
-				event: 'tap',
-				fn: 'onInfoButtonTap'
-			},
-			{
 				delegate: '#staticmap',
 				event: 'tap',
 				fn: 'onNavigationTap'
@@ -101,12 +90,8 @@ Ext.define('WhatsFresh.view.Detail', {
 		console.log('onBackButtonTap');
 		this.fireEvent('viewBackHomeCommand', this);
 	},
-		onNavigationTap: function(index){
-			this.fireEvent('navigationFunction', index.coords);
-		},
-	onInfoButtonTap: function(){
-		console.log('onInfoButtonTap');
-		this.fireEvent('viewInfoCommand', this);
+	onNavigationTap: function(index){
+		this.fireEvent('navigationFunction', index.coords);
 	},
 	onDpagelistDisclose: function(list, record, target, index, evt, options){
 		console.log('viewDpageListItemCommand');

--- a/app/view/Info.js
+++ b/app/view/Info.js
@@ -16,23 +16,17 @@ Ext.define('WhatsFresh.view.Info', {
 				docked: 'top',
 				items: [
 					{
-						xtype: 'button',
-						ui: 'action',
-						text: 'back',
-						itemId: 'backDetailButton'
-					},
-					{
-						xtype: 'button',
-						ui: 'action',
-						text: 'specific',
-						itemId: 'specificButton'
-					},
-					{
 						xtype: 'button', 
 						ui: 'action',
 						// text: 'Home',
 						iconCls: 'home',
 						itemId: 'backHomeButton'
+					},
+					{
+						xtype: 'button',
+						ui: 'action',
+						text: 'back',
+						itemId: 'backDetailButton'
 					}
 				]
 			},
@@ -72,11 +66,6 @@ Ext.define('WhatsFresh.view.Info', {
 				fn: 'onBackButtonTap'
 			},
 			{
-				delegate: '#specificButton',
-				event: 'tap',
-				fn: 'onSpecificButtonTap'
-			},
-			{
 				delegate: '#backHomeButton',
 				event: 'tap',
 				fn: 'onBackHomeButtonTap'
@@ -95,10 +84,6 @@ Ext.define('WhatsFresh.view.Info', {
 	onBackHomeButtonTap: function(){
 		console.log('onBackButtonTap');
 		this.fireEvent('viewBackHomeCommand', this);
-	},
-	onSpecificButtonTap: function(){
-		console.log('onSpecificButtonTap');
-		this.fireEvent('viewSpecificCommand', this);
 	},
 	onIpagelistDisclose: function(list, record, taget, index, evt, option){
 		console.log('viewIpageListItemCommand');

--- a/app/view/ListView.js
+++ b/app/view/ListView.js
@@ -14,23 +14,18 @@ Ext.define('WhatsFresh.view.ListView', {
 				items: [
 					{
 						xtype: 'button',
-						ui: 'action', 
-						text: 'back',
-						itemId: 'HomeButton'
-					},
-					{
-						xtype: 'button',
-						ui: 'action',
-						text: 'Detail',
-						itemId: 'detailButton'
-					},
-					{
-						xtype: 'button',
 						ui: 'action',
 						// text: 'Home',
 						iconCls: 'home',
 						itemId: 'backHomeButton'
+					},
+					{
+						xtype: 'button',
+						ui: 'action', 
+						text: 'back',
+						itemId: 'HomeButton'
 					}
+					
 				]
 			},
 			{
@@ -69,11 +64,6 @@ Ext.define('WhatsFresh.view.ListView', {
 				fn: 'onBackHomeButtonTap'
 			},
 			{
-				delegate: '#detailButton',
-				event: 'tap',
-				fn: 'onDetailButtonTap'
-			},
-			{
 				delegate: '#Lpagelist',
 				event: 'itemsingletap',
 				fn: 'onLpagelistHighlight'
@@ -89,10 +79,6 @@ Ext.define('WhatsFresh.view.ListView', {
 		console.log('onBackButtonTap');
 		WhatsFresh.previousListItem = null;
 		this.fireEvent('viewBackHomeCommand', this);
-	},
-	onDetailButtonTap: function(){
-		console.log('onDetailButtonTap');
-		this.fireEvent('viewDetailCommand', this);
 	},
 	onLpagelistHighlight: function(list, record, target, index, evt, options){
 		console.log('viewLpageListHighlightCommand');

--- a/app/view/ProductDetail.js
+++ b/app/view/ProductDetail.js
@@ -18,21 +18,15 @@ Ext.define('WhatsFresh.view.ProductDetail', {
 					{
 						xtype: 'button',
 						ui: 'action',
-						text: 'Back',
-						itemId: 'backListButton'
-					},
-					{
-						xtype: 'button',
-						ui: 'action',
-						text: 'Info',
-						itemId: 'infoButton'
-					},
-					{
-						xtype: 'button',
-						ui: 'action',
 						// text: 'Home',
 						iconCls: 'home',
 						itemId: 'backHomeButton'
+					},
+					{
+						xtype: 'button',
+						ui: 'action',
+						text: 'Back',
+						itemId: 'backListButton'
 					}
 				]
 			},

--- a/app/view/Specific.js
+++ b/app/view/Specific.js
@@ -14,15 +14,15 @@ Ext.define('WhatsFresh.view.Specific', {
 					{
 						xtype: 'button',
 						ui: 'action',
-						text: 'back',
-						itemId: 'backInfoButton'
+						// text: 'Home',
+						iconCls: 'home',
+						itemId: 'backHomeButton'
 					},
 					{
 						xtype: 'button',
 						ui: 'action',
-						// text: 'Home',
-						iconCls: 'home',
-						itemId: 'backHomeButton'
+						text: 'back',
+						itemId: 'backInfoButton'
 					}
 				]
 			},

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -15,6 +15,10 @@
 	width: 45%;
 }
 
+#ListMap{
+	height: 50%;
+}
+
 #InfoImage{
 	height: 20%;
 	width: 100%;


### PR DESCRIPTION
I got rid of the buttons Detail, Info, and Specific as well as their
listeners, function calls, and functions. I also fixed the map, because it
was showing the map on 100% of the page, but only 50% of the map was
showing because of the list. Thus we made the map 50% of the height.

-------------------------------------------------------------------------------------
This pull request is the same as #28, rebased to include test fixes.