### PR TITLE
Update Location, Product and Vendor stores to use correct staging API

### DIFF
--- a/app/store/Location.js
+++ b/app/store/Location.js
@@ -18,7 +18,7 @@ Ext.define('WhatsFresh.store.Location', {
         },
     	proxy: {
     	    type: 'ajax',
-    	    url: 'http://seagrant-staging.osuosl.org/1/locations',
+    	    url: 'http://seagrant-staging-api.osuosl.org/1/locations',
     	    noCache: false,
             pageParam: false,
             limitParam: false,

--- a/app/store/Product.js
+++ b/app/store/Product.js
@@ -16,7 +16,7 @@ Ext.define('WhatsFresh.store.Product', {
         },
     	proxy: {
     	    type: 'ajax',
-    	    url: 'http://seagrant-staging.osuosl.org/1/products',
+    	    url: 'http://seagrant-staging-api.osuosl.org/1/products',
     	    noCache: false,
             pageParam: false,
             limitParam: false,

--- a/app/store/Vendor.js
+++ b/app/store/Vendor.js
@@ -5,7 +5,7 @@ Ext.define('WhatsFresh.store.Vendor', {
 		autoLoad: true,
 		proxy: {
 		    type: 'ajax',
-		    url: 'http://seagrant-staging.osuosl.org/1/vendors',
+		    url: 'http://seagrant-staging-api.osuosl.org/1/vendors',
 		    noCache: false,
 	        pageParam: false,
 	        limitParam: false,


### PR DESCRIPTION
url

Prior to this commit, the Location, Product and Vendor stores were
pointing to an out-of-date API url. This commit updates this field to
allow the app to make queries against the API.