### PR TITLE
Use phonegap geolocation and fix error msg

### DIFF
--- a/app/util/Messages.js
+++ b/app/util/Messages.js
@@ -9,7 +9,7 @@ Ext.define('WhatsFresh.util.Messages', {
 			'Location Error', [
 				'Unable to get location!<br><br>',
 				'Check your device\'s privacy settings to see if ',
-				'location services are enabled.'
+				'location services are enabled and restart the app.'
 			].join(''),
 			cb || Ext.emptyFn);
 	}


### PR DESCRIPTION
We switched the geolocation back to using phonegap geolocation, so that
geolocation would work ok with all of the different android versions. Then
we added a line to the error message that comes up when the user trys to
search by location, but can't. The added msg lets them know that they need
to restart the app after they have turned location services on for their
device.