### PR TITLE
Relocate Google maps resource link from index.html to app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -76,10 +76,6 @@
      *      }
      */
     "js": [
-	{
-	    "path": "phonegap.js",
-	    "remote": true
-	},
         {
             "path": "touch/sencha-touch.js",
             "x-bootstrap": true
@@ -87,6 +83,10 @@
         {
             "path": "bootstrap.js",
             "x-bootstrap": true
+        },
+        {
+            "path": "https://maps.google.com/maps/api/js?sensor=true",
+            "remote": true
         },
         {
             "path": "app.js",

--- a/index.html
+++ b/index.html
@@ -51,11 +51,8 @@
         }
     </style>
     <!-- The line below must be kept intact for Sencha Command to build your application -->
-    <script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=true"></script>
-    <script id="microloader" type="text/javascript" src=".sencha/app/microloader/development.js"></script>
 
-    <!--<script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=true&libraries=panoramio"></script>
-    <script src="http://maps.googleapis.com/maps/api/js?key=AIzaSyDY0kkJiTPVd2U7aTOAwhc9ySH6oHxOIYM&sensor=false"></script>-->
+    <script id="microloader" type="text/javascript" src=".sencha/app/microloader/development.js"></script>
     
 </head>
 <body>


### PR DESCRIPTION
Prior to this commit, the app was unable to launch on iOS devices due
to an error loading/connecting to the Google Maps javascript api
resources. This commit moves the reference to the Google Maps api from
the index.html file to the app.json `resources` object. As of this
commit, the app is able to launch on iOS devices *if* it is able to
connect to the internet.