### PR TITLE
Add store load status tracking and generic error

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ Ext.Loader.setConfig({
         "Ext": 'touch/src'
     }
 });
- 
+
 Ext.application({
     name: 'WhatsFresh',
 
@@ -25,6 +25,8 @@ Ext.application({
     models: ["Vendors", "Products", "Locations", "VendorInventories", "ProductLists", "Stories"],
     stores: ["Education", "Vendor", "Product", "Location", "Distance", "VendorInventory", "ProductList", "Story"],
     views: ["Home", "Detail", "ListView", "Map", "Info", "Specific", "ProductDetail"],
+
+    requires: ['WhatsFresh.util.StoreLoadTracking'],
 
 
     launch: function() {
@@ -36,10 +38,19 @@ Ext.application({
         Ext.Viewport.add(Ext.create('WhatsFresh.view.Home'));
         Ext.Viewport.add(Ext.create('WhatsFresh.view.Map'));
         Ext.Viewport.add(Ext.create('WhatsFresh.view.ListView'));
-        Ext.Viewport.add(Ext.create('WhatsFresh.view.Detail')); 
-        Ext.Viewport.add(Ext.create('WhatsFresh.view.ProductDetail')); 
+        Ext.Viewport.add(Ext.create('WhatsFresh.view.Detail'));
+        Ext.Viewport.add(Ext.create('WhatsFresh.view.ProductDetail'));
         Ext.Viewport.add(Ext.create('WhatsFresh.view.Info'));
         Ext.Viewport.add(Ext.create('WhatsFresh.view.Specific'));
+
+        var SLT = WhatsFresh.util.StoreLoadTracking;
+        SLT.registerStore('Location');
+    	SLT.registerStore('Product');
+    	SLT.registerStore('Vendor');
+
+    	// To override the error throwing behavior,
+    	// Redefine function in singleton:
+    	//SLT.StoreLoadError = function () {}
 
         // This is used to iplement android back button
         if(Ext.os.is('Android')){
@@ -52,7 +63,7 @@ Ext.application({
                 }
                 // Action is like a fired event from a view page, routes are assigned
                 // for the url sent back in the controller routes section. The routes
-                // section in the controller defines which function to call when an 
+                // section in the controller defines which function to call when an
                 // action is sent to the controller from the device back button
                 if(Ext.Viewport.getActiveItem().xtype ==  WhatsFresh.view.ListView.xtype){
                     this.getApplication().getHistory().add(Ext.create('Ext.app.Action', {

--- a/app/util/StoreLoadTracking.js
+++ b/app/util/StoreLoadTracking.js
@@ -1,0 +1,40 @@
+Ext.define('WhatsFresh.util.StoreLoadTracking', {
+
+	singleton: true,
+
+	StoreLoadStatus: {},
+
+    StoreLoadError: function () { console.error('Unhandled store load error.'); },
+
+    // Returns true if stores all called back and at least one has an error.
+    hasStoreLoadError: function () {
+    	var util = this;
+		var error = false;
+		for (var s in util.StoreLoadStatus) {
+			if (!util.StoreLoadStatus[s].called) return false;
+			if (!util.StoreLoadStatus[s].loaded) error = true;
+		}
+		return error;
+	},
+
+	// Call this during launch.
+    registerStore: function (name) {
+    	var util = this;
+		// Add to the list to track.
+		util.StoreLoadStatus[name] = {
+			called	: false,
+			loaded	: false
+		};
+		Ext.getStore(name).on('beforeload', function (store, operation) {
+			util.StoreLoadStatus[name].called = false;
+		});
+		// Attach load event handler.
+		Ext.getStore(name).on('load', function (vThis, records, success) {
+			util.StoreLoadStatus[name].called = true;
+    		if (success) util.StoreLoadStatus[name].loaded = true;
+    		else util.StoreLoadStatus[name].loaded = false;
+    		if (util.hasStoreLoadError()) util.StoreLoadError();
+    	});
+	}
+
+});

--- a/app/util/StoreLoadTracking.js
+++ b/app/util/StoreLoadTracking.js
@@ -4,6 +4,8 @@ Ext.define('WhatsFresh.util.StoreLoadTracking', {
 
 	StoreLoadStatus: {},
 
+    StoreLoadSuccess: function () { console.log('Unhandled store load success.'); },
+
     StoreLoadError: function () { console.error('Unhandled store load error.'); },
 
     // Returns true if stores all called back and at least one has an error.
@@ -15,6 +17,15 @@ Ext.define('WhatsFresh.util.StoreLoadTracking', {
 			if (!util.StoreLoadStatus[s].loaded) error = true;
 		}
 		return error;
+	},
+
+	// Returns true if stores all called back
+    areStoresDone: function () {
+    	var util = this;
+		for (var s in util.StoreLoadStatus) {
+			if (!util.StoreLoadStatus[s].called) return false;
+		}
+		return true;
 	},
 
 	// Call this during launch.
@@ -33,7 +44,10 @@ Ext.define('WhatsFresh.util.StoreLoadTracking', {
 			util.StoreLoadStatus[name].called = true;
     		if (success) util.StoreLoadStatus[name].loaded = true;
     		else util.StoreLoadStatus[name].loaded = false;
-    		if (util.hasStoreLoadError()) util.StoreLoadError();
+    		if (util.areStoresDone()) {
+    			if (util.hasStoreLoadError()) util.StoreLoadError();
+    			else util.StoreLoadSuccess();
+    		}
     	});
 	}
 


### PR DESCRIPTION
A new util simplifies the task of tracking remotely populated stores of their success or error states. At the callback of any registered store, if all stores have called back, yet any failed to load, a singleton store load error function is called.